### PR TITLE
fix: fix QuickTime-incompatible MP4 downloads on macOS

### DIFF
--- a/python/downloader.py
+++ b/python/downloader.py
@@ -828,6 +828,8 @@ class YouTubeDownloader:
         normalized = str(codec or "").strip().lower()
         if normalized in ("", "none"):
             return True
+        if normalized.startswith("mp4a."):
+            return True
         return normalized in ("aac", "mp3", "ac3", "eac3", "alac")
 
     @staticmethod

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -2436,6 +2436,19 @@ class TestDownloadVideo:
             is True
         )
 
+    def test_requires_mp4_compatibility_transcode_allows_mp4a_audio_codec_probe(self):
+        """mp4a.* audio variants should be treated as QuickTime-compatible."""
+        assert (
+            YouTubeDownloader._requires_mp4_compatibility_transcode(
+                Path("source.mp4"),
+                Path("output.mp4"),
+                None,
+                source_video_codec="h264",
+                source_audio_codec="mp4a.40.2",
+            )
+            is False
+        )
+
     def test_download_transcodes_non_mp4_source_for_mp4_output(self, temp_dir, sample_video_info):
         """When source is webm and output is mp4, downloader should run compatibility transcode."""
         output_file = temp_dir / "output.mp4"


### PR DESCRIPTION
## Summary
- fix root cause where `.mp4` outputs could still contain QuickTime-incompatible codecs (e.g. AV1/VP9)
- add ffprobe-based primary stream codec detection before finalizing MP4 output
- enforce QuickTime compatibility transcode when probed codecs are incompatible (H.264/AAC target)
- keep existing selected-format metadata checks as fallback

## Why this fixes the released bug
Previously, transcode decisions could rely on yt-dlp selected-format metadata, which can be missing/optimistic for merged or cached MP4 files. That allowed incompatible codecs to slip through inside MP4 containers. This change validates actual output stream codecs, so incompatible MP4 video is always transcoded.

## Tests
- added unit tests for incompatible codec probe behavior and precedence over selected-format metadata
- added unit test covering end-to-end transcode trigger for mp4+AV1 source path
- `python3 -m pytest python/test_downloader.py -q` -> 157 passed
- pre-push checks passed: biome, clippy, ruff, shellcheck, typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  - Better detection of source video/audio codecs to more accurately determine when MP4 transcoding is needed
  - More reliable MP4 compatibility checks and smarter transcoding decisions for improved playback across devices
  - Improved handling of cut vs. full-download workflows to ensure correct final file output

* **Tests**
  - New unit tests covering MP4 compatibility probing and transcoding behaviors to prevent regressions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->