### PR TITLE
fix: enforce cross-platform runnable bundled python and default to h264/aac mp4 without forced transcode

### DIFF
--- a/python/downloader.py
+++ b/python/downloader.py
@@ -29,7 +29,7 @@ MAX_RETRY_DELAY = 3.0
 RETRY_BACKOFF_MULTIPLIER = 1.5
 INCOMPLETE_FILE_EXTENSIONS = (".part", ".ytdl")
 VIDEO_EXTENSIONS = ["mp4", "webm", "mkv", "m4a", "flv", "avi", "mov"]
-CACHE_KEY_VERSION = "hqv2"
+CACHE_KEY_VERSION = "hqv3"
 SUPPORTED_COOKIE_BROWSERS = {
     "brave",
     "chrome",
@@ -240,10 +240,10 @@ class YouTubeDownloader:
 
     @staticmethod
     def _build_format_selectors(quality: str) -> list[str]:
-        """Build selectors that prioritize broadly compatible MP4 outputs."""
+        """Build selectors that prioritize H.264/AAC MP4 compatibility."""
         requested_quality = quality.strip() if quality else ""
-        # Generic HQ selectors often choose AV1/WebM and force slow post-transcode.
-        # Default to MP4-first selectors unless caller requested a specific constrained format.
+        # Generic HQ selectors often choose AV1/VP9 and force expensive post-transcode.
+        # Normalize these to compatibility-first defaults.
         if requested_quality in {
             "bestvideo*+bestaudio",
             "bv*+ba",
@@ -254,10 +254,14 @@ class YouTubeDownloader:
 
         candidates = [
             requested_quality,
-            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[ext=m4a][acodec!=none]",
-            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[acodec!=none]",
-            "best[ext=mp4][vcodec!=none][acodec!=none]",
-            "best[ext=mp4]/best",
+            "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a][acodec^=mp4a]"
+            "/bestvideo[ext=mp4][vcodec^=h264]+bestaudio[ext=m4a][acodec^=mp4a]"
+            "/bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a][acodec^=aac]"
+            "/bestvideo[ext=mp4][vcodec^=h264]+bestaudio[ext=m4a][acodec^=aac]",
+            "best[ext=mp4][vcodec^=avc1][acodec^=mp4a]"
+            "/best[ext=mp4][vcodec^=h264][acodec^=mp4a]"
+            "/best[ext=mp4][vcodec^=avc1][acodec^=aac]"
+            "/best[ext=mp4][vcodec^=h264][acodec^=aac]",
         ]
         selectors: list[str] = []
         for selector in candidates:
@@ -267,11 +271,12 @@ class YouTubeDownloader:
 
     @staticmethod
     def _build_restricted_format_selectors() -> list[str]:
-        """Fallback selectors for restricted videos where HQ streams return 403."""
+        """Fallback selectors for restricted videos while staying H.264/AAC MP4."""
         return [
-            "best[ext=mp4][vcodec!=none][acodec!=none]",
-            "best[vcodec!=none][acodec!=none]",
-            "best[ext=mp4]/best",
+            "best[ext=mp4][vcodec^=avc1][acodec^=mp4a]"
+            "/best[ext=mp4][vcodec^=h264][acodec^=mp4a]"
+            "/best[ext=mp4][vcodec^=avc1][acodec^=aac]"
+            "/best[ext=mp4][vcodec^=h264][acodec^=aac]",
         ]
 
     @staticmethod
@@ -1760,7 +1765,8 @@ class YouTubeDownloader:
                 },
             )
 
-        requires_mp4_compat = self._requires_mp4_compatibility_transcode(
+        enable_mp4_compat_transcode = self._is_truthy_env("YT_DLP_ENABLE_MP4_COMPAT_TRANSCODE", default=False)
+        requires_mp4_compat = enable_mp4_compat_transcode and self._requires_mp4_compatibility_transcode(
             transcode_input,
             final_path_obj,
             progress_tracker.selected_format,
@@ -1791,6 +1797,15 @@ class YouTubeDownloader:
                     ),
                     video_info=video_info,
                 )
+        elif not enable_mp4_compat_transcode:
+            self._emit_debug_event(
+                "quality_debug",
+                {
+                    "event": "mp4_compat_transcode_disabled",
+                    "input_path": str(transcode_input),
+                    "output_path": str(final_path_obj),
+                },
+            )
 
         # Verify the cached file still exists in temp directory
         cached_file_path_str = None

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -1782,10 +1782,14 @@ class TestDownloadVideo:
         """Default selectors should prioritize MP4-compatible formats."""
         selectors = YouTubeDownloader._build_format_selectors("bestvideo*+bestaudio")
         assert selectors == [
-            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[ext=m4a][acodec!=none]",
-            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[acodec!=none]",
-            "best[ext=mp4][vcodec!=none][acodec!=none]",
-            "best[ext=mp4]/best",
+            "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a][acodec^=mp4a]"
+            "/bestvideo[ext=mp4][vcodec^=h264]+bestaudio[ext=m4a][acodec^=mp4a]"
+            "/bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a][acodec^=aac]"
+            "/bestvideo[ext=mp4][vcodec^=h264]+bestaudio[ext=m4a][acodec^=aac]",
+            "best[ext=mp4][vcodec^=avc1][acodec^=mp4a]"
+            "/best[ext=mp4][vcodec^=h264][acodec^=mp4a]"
+            "/best[ext=mp4][vcodec^=avc1][acodec^=aac]"
+            "/best[ext=mp4][vcodec^=h264][acodec^=aac]",
         ]
 
     def test_browser_cookie_candidates_support_csv(self):
@@ -1884,9 +1888,12 @@ class TestDownloadVideo:
                                         )
                                         assert result.success is True
                                         attempted_non_empty = [fmt for fmt in attempted_formats if fmt]
+                                        default_selector = YouTubeDownloader._build_format_selectors(
+                                            "bestvideo*+bestaudio"
+                                        )[0]
                                         assert attempted_non_empty[:2] == [
                                             "nonexistent",
-                                            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[ext=m4a][acodec!=none]",
+                                            default_selector,
                                         ]
 
     def test_download_ffmpeg_merge_error_does_not_fallback_to_progressive(self, temp_dir, sample_video_info):
@@ -1938,9 +1945,8 @@ class TestDownloadVideo:
                         assert result.success is False
                         assert "FFmpeg is required" in (result.error_message or "")
                         attempted_non_empty = [fmt for fmt in attempted_formats if fmt]
-                        assert attempted_non_empty == [
-                            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[ext=m4a][acodec!=none]"
-                        ]
+                        default_selector = YouTubeDownloader._build_format_selectors("bestvideo*+bestaudio")[0]
+                        assert attempted_non_empty == [default_selector]
 
     def test_download_ffmpeg_merging_error_does_not_fallback_to_progressive(self, temp_dir, sample_video_info):
         """If yt-dlp reports `merging` wording, fail explicitly instead of low quality fallback."""
@@ -1994,9 +2000,8 @@ class TestDownloadVideo:
                         assert result.success is False
                         assert "FFmpeg is required" in (result.error_message or "")
                         attempted_non_empty = [fmt for fmt in attempted_formats if fmt]
-                        assert attempted_non_empty == [
-                            "bestvideo[ext=mp4][vcodec!=none]+bestaudio[ext=m4a][acodec!=none]"
-                        ]
+                        default_selector = YouTubeDownloader._build_format_selectors("bestvideo*+bestaudio")[0]
+                        assert attempted_non_empty == [default_selector]
 
     def test_download_falls_back_to_restricted_progressive_on_403(self, temp_dir, sample_video_info):
         """When HQ streams are blocked (403), fallback profile should download progressive format."""
@@ -2505,15 +2510,20 @@ class TestDownloadVideo:
                                         "_transcode_to_quicktime_mp4",
                                         side_effect=lambda _src, dst: Path(dst).write_bytes(b"qtmp4") or True,
                                     ) as mock_transcode:
-                                        result = downloader.download_video(
-                                            "https://youtube.com/watch?v=test",
-                                            str(output_file),
-                                        )
-                                        assert result.success is True
-                                        mock_transcode.assert_called_once()
-                                        called_src, called_dst = mock_transcode.call_args.args
-                                        assert called_src == downloaded_file
-                                        assert called_dst == output_file
+                                        with patch.dict(
+                                            os.environ,
+                                            {"YT_DLP_ENABLE_MP4_COMPAT_TRANSCODE": "true"},
+                                            clear=False,
+                                        ):
+                                            result = downloader.download_video(
+                                                "https://youtube.com/watch?v=test",
+                                                str(output_file),
+                                            )
+                                            assert result.success is True
+                                            mock_transcode.assert_called_once()
+                                            called_src, called_dst = mock_transcode.call_args.args
+                                            assert called_src == downloaded_file
+                                            assert called_dst == output_file
 
     def test_download_transcodes_incompatible_mp4_codec_for_mp4_output(self, temp_dir, sample_video_info):
         """When source is mp4+AV1, downloader should run compatibility transcode."""
@@ -2576,16 +2586,21 @@ class TestDownloadVideo:
                                             "_transcode_to_quicktime_mp4",
                                             side_effect=lambda _src, dst: Path(dst).write_bytes(b"qtmp4") or True,
                                         ) as mock_transcode:
-                                            result = downloader.download_video(
-                                                "https://youtube.com/watch?v=test",
-                                                str(output_file),
-                                            )
-                                            assert result.success is True
-                                            mock_probe.assert_called_once_with(downloaded_file)
-                                            mock_transcode.assert_called_once()
-                                            called_src, called_dst = mock_transcode.call_args.args
-                                            assert called_src == downloaded_file
-                                            assert called_dst == output_file
+                                            with patch.dict(
+                                                os.environ,
+                                                {"YT_DLP_ENABLE_MP4_COMPAT_TRANSCODE": "true"},
+                                                clear=False,
+                                            ):
+                                                result = downloader.download_video(
+                                                    "https://youtube.com/watch?v=test",
+                                                    str(output_file),
+                                                )
+                                                assert result.success is True
+                                                mock_probe.assert_called_once_with(downloaded_file)
+                                                mock_transcode.assert_called_once()
+                                                called_src, called_dst = mock_transcode.call_args.args
+                                                assert called_src == downloaded_file
+                                                assert called_dst == output_file
 
     def test_download_transcodes_incompatible_mp4_codec_for_cut_output(self, temp_dir, sample_video_info):
         """When needs_cut=True, transcode should run with identical src/dst output path."""
@@ -2650,18 +2665,23 @@ class TestDownloadVideo:
                                             "_transcode_to_quicktime_mp4",
                                             side_effect=lambda _src, dst: Path(dst).write_bytes(b"qtmp4") or True,
                                         ) as mock_transcode:
-                                            result = downloader.download_video(
-                                                "https://youtube.com/watch?v=test",
-                                                str(output_file),
-                                                start_time=10,
-                                                end_time=30,
-                                            )
-                                            assert result.success is True
-                                            mock_probe.assert_called_once_with(output_file)
-                                            mock_transcode.assert_called_once()
-                                            called_src, called_dst = mock_transcode.call_args.args
-                                            assert called_src == output_file
-                                            assert called_dst == output_file
+                                            with patch.dict(
+                                                os.environ,
+                                                {"YT_DLP_ENABLE_MP4_COMPAT_TRANSCODE": "true"},
+                                                clear=False,
+                                            ):
+                                                result = downloader.download_video(
+                                                    "https://youtube.com/watch?v=test",
+                                                    str(output_file),
+                                                    start_time=10,
+                                                    end_time=30,
+                                                )
+                                                assert result.success is True
+                                                mock_probe.assert_called_once_with(output_file)
+                                                mock_transcode.assert_called_once()
+                                                called_src, called_dst = mock_transcode.call_args.args
+                                                assert called_src == output_file
+                                                assert called_dst == output_file
 
     def test_download_fails_when_mp4_compat_transcode_fails(self, temp_dir, sample_video_info):
         """If compatibility transcode fails, downloader should return clear failure."""
@@ -2719,12 +2739,17 @@ class TestDownloadVideo:
                                         "_transcode_to_quicktime_mp4",
                                         return_value=False,
                                     ):
-                                        result = downloader.download_video(
-                                            "https://youtube.com/watch?v=test",
-                                            str(output_file),
-                                        )
-                                        assert result.success is False
-                                        assert "QuickTime-compatible" in (result.error_message or "")
+                                        with patch.dict(
+                                            os.environ,
+                                            {"YT_DLP_ENABLE_MP4_COMPAT_TRANSCODE": "true"},
+                                            clear=False,
+                                        ):
+                                            result = downloader.download_video(
+                                                "https://youtube.com/watch?v=test",
+                                                str(output_file),
+                                            )
+                                            assert result.success is False
+                                            assert "QuickTime-compatible" in (result.error_message or "")
 
     def test_download_live_stream(self, temp_dir, mock_ytdlp_download, sample_live_video_info):
         """Test downloading live stream"""

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,7 +328,7 @@ fn run_download_video(
         script_path.to_string_lossy().to_string(),
         validated_url.clone(),
         "false".to_string(),
-        "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best".to_string(),
+        "bestvideo*+bestaudio".to_string(),
         sections_json,
         validated.save_path.to_string_lossy().to_string(),
     ];
@@ -794,6 +794,13 @@ fn validate_python_path_for_mode(python_path: &Path) -> Result<(), String> {
             python_path.to_string_lossy()
         ));
     }
+    if !python_executable_works(python_path) {
+        return Err(format!(
+            "Configuration error: Python executable is not runnable at: {}. \
+The bundled runtime likely does not match this OS/architecture.",
+            python_path.to_string_lossy()
+        ));
+    }
     Ok(())
 }
 
@@ -878,7 +885,7 @@ fn resolve_dev_python_path() -> Option<PathBuf> {
             .join("bin")
             .join("python3")
     };
-    if bundled_python.exists() {
+    if bundled_python.exists() && python_executable_works(&bundled_python) {
         return Some(bundled_python);
     }
 
@@ -939,6 +946,17 @@ fn command_available(command: &str) -> bool {
         .stderr(Stdio::null())
         .status()
         .is_ok()
+}
+
+fn python_executable_works(path: &Path) -> bool {
+    Command::new(path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 fn is_dev_mode() -> bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment flag to control MP4 compatibility transcoding behavior.
  * Introduced runtime validation for Python availability with improved error messaging.

* **Bug Fixes**
  * Improved format selection logic to prioritize H.264/AAC MP4 compatibility.
  * Enhanced video/audio quality selector with more flexible codec support.

* **Chores**
  * Updated internal cache versioning and test coverage for format selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->