### PR TITLE
fix: sync bundled yt-dlp, auto-close stale issues, respect cookie opt-out

### DIFF
--- a/.github/workflows/nightly-download-test.yml
+++ b/.github/workflows/nightly-download-test.yml
@@ -117,17 +117,23 @@ jobs:
     steps:
       - name: Close resolved yt-dlp update issues
         uses: actions/github-script@v7
+        env:
+          PINNED: ${{ needs.check-ytdlp-version.outputs.pinned }}
         with:
           script: |
-            const pinned = '${{ needs.check-ytdlp-version.outputs.pinned }}';
+            const pinned = process.env.PINNED;
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
+              creator: 'github-actions[bot]',
               labels: 'yt-dlp-update',
               per_page: 100,
             });
             for (const issue of existing) {
+              if (!issue.title.startsWith('yt-dlp update available:')) {
+                continue;
+              }
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/nightly-download-test.yml
+++ b/.github/workflows/nightly-download-test.yml
@@ -106,3 +106,40 @@ jobs:
               body,
               labels: ['yt-dlp-update'],
             });
+
+  close-ytdlp-update-issues:
+    name: close-ytdlp-update-issues
+    runs-on: ubuntu-latest
+    needs: check-ytdlp-version
+    if: needs.check-ytdlp-version.outputs.stale == 'false'
+    permissions:
+      issues: write
+    steps:
+      - name: Close resolved yt-dlp update issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pinned = '${{ needs.check-ytdlp-version.outputs.pinned }}';
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'yt-dlp-update',
+              per_page: 100,
+            });
+            for (const issue of existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Auto-closed: \`python/requirements.txt\` now pins yt-dlp ${pinned}, which matches the latest PyPI release.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              console.log('Closed issue:', issue.html_url);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Always use conventional commit messages.
 
-## Cursor Cloud specific instructions
+## Cursor Cloud-specific instructions
 
 ### Overview
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
 # `default` extra includes `yt-dlp-ejs`, used by fetch_pot integration.
-yt-dlp[default]==2026.3.17
+yt-dlp[default]==2026.6.9
 pytest>=9.0.2
 pytest-mock>=3.12.0

--- a/scripts/local-nightly-test.sh
+++ b/scripts/local-nightly-test.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # Local real-world download test (runs via launchd on residential IP).
 # On failure, creates a GitHub issue in the repo.
+# On success, closes any open nightly-failure issues.
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 LOG_FILE="$REPO_DIR/.local-nightly-test.log"
+GH_REPO="arpitdalal/yt-downloader"
 
 exec > "$LOG_FILE" 2>&1
 echo "=== $(date) ==="
 
 cd "$REPO_DIR"
 
-# Ensure bundled python + yt-dlp exist; re-bundle if missing
+# Ensure bundled python exists; full re-bundle only when missing
 PYTHON_DIR="$REPO_DIR/src-tauri/resources/python"
 if [ ! -f "$PYTHON_DIR/bin/python3" ]; then
   echo "Bundled Python missing, running bundle script..."
@@ -21,6 +23,12 @@ fi
 PYTHON="$PYTHON_DIR/bin/python3"
 FFMPEG="$REPO_DIR/src-tauri/resources/ffmpeg/ffmpeg"
 
+# Keep bundled yt-dlp/pytest aligned with requirements.txt (avoids stale runtime)
+echo "Syncing bundled Python dependencies from requirements.txt..."
+"$PYTHON" -m pip install -q -r "$REPO_DIR/python/requirements.txt"
+cp "$REPO_DIR/python/downloader.py" "$PYTHON_DIR/downloader.py"
+echo "Bundled yt-dlp: $("$PYTHON" -m pip show yt-dlp | awk '/^Version:/{print $2}')"
+
 export RUN_REAL_WORLD_TESTS=1
 export YT_DLP_ENABLE_BROWSER_COOKIES=false
 [ -f "$FFMPEG" ] && export FFMPEG_PATH="$FFMPEG"
@@ -28,9 +36,35 @@ export YT_DLP_ENABLE_BROWSER_COOKIES=false
 # Add gh to PATH (Homebrew on Apple Silicon)
 export PATH="/opt/homebrew/bin:$PATH"
 
+close_nightly_failure_issues() {
+  local issue_numbers
+  issue_numbers=$(gh issue list \
+    --repo "$GH_REPO" \
+    --label nightly-failure \
+    --state open \
+    --json number -q '.[].number' 2>/dev/null || true)
+
+  if [ -z "$issue_numbers" ]; then
+    echo "No open nightly-failure issues to close."
+    return 0
+  fi
+
+  local closed=0
+  for issue_number in $issue_numbers; do
+    gh issue close "$issue_number" \
+      --repo "$GH_REPO" \
+      --comment "Auto-closed: real-world download tests passed on $(date +%Y-%m-%d)." \
+      >/dev/null
+    echo "Closed issue #$issue_number"
+    closed=$((closed + 1))
+  done
+  echo "Closed $closed nightly-failure issue(s)."
+}
+
 echo "Running real-world download tests..."
 if "$PYTHON" -m pytest python/test_downloader_real_world.py -s -v 2>&1; then
   echo "All tests passed."
+  close_nightly_failure_issues
   exit 0
 fi
 
@@ -41,7 +75,7 @@ TITLE="Local nightly download test failed on $DATE"
 
 # Check for duplicate open issue
 EXISTING=$(gh issue list \
-  --repo arpitdalal/yt-downloader \
+  --repo "$GH_REPO" \
   --label nightly-failure \
   --state open \
   --search "$TITLE" \
@@ -53,7 +87,7 @@ if echo "$EXISTING" | grep -qF "$TITLE"; then
 fi
 
 gh issue create \
-  --repo arpitdalal/yt-downloader \
+  --repo "$GH_REPO" \
   --title "$TITLE" \
   --body "Real-world download test failed on local Mac (residential IP).
 

--- a/scripts/local-nightly-test.sh
+++ b/scripts/local-nightly-test.sh
@@ -51,12 +51,15 @@ close_nightly_failure_issues() {
 
   local closed=0
   for issue_number in $issue_numbers; do
-    gh issue close "$issue_number" \
-      --repo "$GH_REPO" \
-      --comment "Auto-closed: real-world download tests passed on $(date +%Y-%m-%d)." \
-      >/dev/null
-    echo "Closed issue #$issue_number"
-    closed=$((closed + 1))
+    if gh issue close "$issue_number" \
+        --repo "$GH_REPO" \
+        --comment "Auto-closed: real-world download tests passed on $(date +%Y-%m-%d)." \
+        >/dev/null; then
+      echo "Closed issue #$issue_number"
+      closed=$((closed + 1))
+    else
+      echo "Failed to close issue #$issue_number"
+    fi
   done
   echo "Closed $closed nightly-failure issue(s)."
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "serial_test",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -3251,6 +3252,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3870,7 +3896,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,3 +25,6 @@ tauri = { version = "2.11.0", features = [] }
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-log = "2"
 url = "2.5.7"
+
+[dev-dependencies]
+serial_test = "3.2.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -629,6 +629,29 @@ fn default_cookie_browser_list() -> &'static str {
     }
 }
 
+fn push_cookie_selection_env_overrides(
+    env_overrides: &mut Vec<(&'static str, String)>,
+    selection: &CookieSelection,
+    selected_cookie_sources: Option<&[CookieSource]>,
+) -> Result<(), String> {
+    let mode = parse_cookie_selection_mode(&selection.mode)?;
+    let enable_browser_cookies =
+        env::var("YT_DLP_ENABLE_BROWSER_COOKIES").unwrap_or_else(|_| "true".to_string());
+    let cookies_enabled = env_truthy_from_value(&enable_browser_cookies, true);
+    env_overrides.push(("YT_DLP_ENABLE_BROWSER_COOKIES", enable_browser_cookies));
+    env_overrides.push(("YT_DLP_COOKIE_SELECTION_MODE", mode.to_string()));
+    if cookies_enabled {
+        if let Some(explicit_sources) =
+            selected_cookie_sources.filter(|sources| !sources.is_empty())
+        {
+            let explicit_sources_json =
+                serde_json::to_string(explicit_sources).unwrap_or_else(|_| "[]".to_string());
+            env_overrides.push(("YT_DLP_COOKIE_SOURCES_JSON", explicit_sources_json));
+        }
+    }
+    Ok(())
+}
+
 fn yt_dlp_env_overrides(
     app: &AppHandle,
     ffmpeg_path: Option<&Path>,
@@ -641,16 +664,11 @@ fn yt_dlp_env_overrides(
     }
 
     if let Some(selection) = cookie_selection {
-        let mode = parse_cookie_selection_mode(&selection.mode)?;
-        env_overrides.push(("YT_DLP_ENABLE_BROWSER_COOKIES", "true".to_string()));
-        env_overrides.push(("YT_DLP_COOKIE_SELECTION_MODE", mode.to_string()));
-        if let Some(explicit_sources) =
-            selected_cookie_sources.filter(|sources| !sources.is_empty())
-        {
-            let explicit_sources_json =
-                serde_json::to_string(explicit_sources).unwrap_or_else(|_| "[]".to_string());
-            env_overrides.push(("YT_DLP_COOKIE_SOURCES_JSON", explicit_sources_json));
-        }
+        push_cookie_selection_env_overrides(
+            &mut env_overrides,
+            selection,
+            selected_cookie_sources,
+        )?;
     } else {
         let enable_browser_cookies =
             env::var("YT_DLP_ENABLE_BROWSER_COOKIES").unwrap_or_else(|_| "true".to_string());
@@ -1344,14 +1362,20 @@ fn get_ffmpeg_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(path)
 }
 
+fn env_truthy_from_value(value: &str, default: bool) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return default;
+    }
+    matches!(
+        trimmed.to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 fn env_truthy(var_name: &str, default: bool) -> bool {
     match env::var(var_name) {
-        Ok(value) => {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        }
+        Ok(value) => env_truthy_from_value(&value, default),
         Err(_) => default,
     }
 }
@@ -2165,6 +2189,61 @@ mod tests {
         #[cfg(not(target_os = "windows"))]
         {
             String::from("/tmp/video.mp4")
+        }
+    }
+
+    #[test]
+    fn env_truthy_from_value_handles_common_false_values() {
+        assert!(!super::env_truthy_from_value("false", true));
+        assert!(!super::env_truthy_from_value("0", true));
+        assert!(!super::env_truthy_from_value("off", true));
+        assert!(super::env_truthy_from_value("true", false));
+        assert!(super::env_truthy_from_value("", true));
+    }
+
+    #[test]
+    fn cookie_selection_env_skips_sources_when_cookies_disabled() {
+        let previous = env::var("YT_DLP_ENABLE_BROWSER_COOKIES").ok();
+        unsafe {
+            env::set_var("YT_DLP_ENABLE_BROWSER_COOKIES", "false");
+        }
+
+        let selection = CookieSelection {
+            mode: "auto".to_string(),
+            source_id: None,
+        };
+        let sources = [CookieSource {
+            id: "chrome_default".to_string(),
+            browser: "chrome".to_string(),
+            browser_label: "Chrome".to_string(),
+            profile: None,
+            profile_label: None,
+            container: None,
+            keyring: None,
+            available: true,
+            has_youtube_cookies: true,
+            has_youtube_auth_cookies: true,
+            last_error: None,
+            priority: 0,
+        }];
+        let mut env_overrides = Vec::new();
+        super::push_cookie_selection_env_overrides(&mut env_overrides, &selection, Some(&sources))
+            .expect("cookie env overrides");
+
+        assert!(env_overrides
+            .iter()
+            .any(|(key, value)| *key == "YT_DLP_ENABLE_BROWSER_COOKIES" && value == "false"));
+        assert!(!env_overrides
+            .iter()
+            .any(|(key, _)| *key == "YT_DLP_COOKIE_SOURCES_JSON"));
+
+        match previous {
+            Some(value) => unsafe {
+                env::set_var("YT_DLP_ENABLE_BROWSER_COOKIES", value);
+            },
+            None => unsafe {
+                env::remove_var("YT_DLP_ENABLE_BROWSER_COOKIES");
+            },
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -356,8 +356,11 @@ fn run_extract_video_info(
         validated_url.clone(),
     ];
 
-    let selected_cookie_sources =
-        resolve_cookie_sources_for_selection(&app, &state, cookie_selection.as_ref())?;
+    let selected_cookie_sources = if browser_cookies_env_enabled() {
+        resolve_cookie_sources_for_selection(&app, &state, cookie_selection.as_ref())?
+    } else {
+        None
+    };
     let python_dir = get_python_working_dir(&python_path);
     let env_overrides = yt_dlp_env_overrides(
         &app,
@@ -434,8 +437,11 @@ fn run_download_video(
         validated.save_path.to_string_lossy().to_string(),
     ];
 
-    let selected_cookie_sources =
-        resolve_cookie_sources_for_selection(&app, &state, options.cookie_selection.as_ref())?;
+    let selected_cookie_sources = if browser_cookies_env_enabled() {
+        resolve_cookie_sources_for_selection(&app, &state, options.cookie_selection.as_ref())?
+    } else {
+        None
+    };
     let python_dir = get_python_working_dir(&python_path);
     let env_overrides = download_env_overrides(
         &app,
@@ -1362,15 +1368,19 @@ fn get_ffmpeg_path(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(path)
 }
 
-fn env_truthy_from_value(value: &str, default: bool) -> bool {
+fn env_truthy_from_value(value: &str, _default: bool) -> bool {
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        return default;
+        return false;
     }
     matches!(
         trimmed.to_ascii_lowercase().as_str(),
         "1" | "true" | "yes" | "on"
     )
+}
+
+fn browser_cookies_env_enabled() -> bool {
+    env_truthy("YT_DLP_ENABLE_BROWSER_COOKIES", true)
 }
 
 fn env_truthy(var_name: &str, default: bool) -> bool {
@@ -1861,6 +1871,7 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn validates_youtube_urls() {
@@ -2198,10 +2209,11 @@ mod tests {
         assert!(!super::env_truthy_from_value("0", true));
         assert!(!super::env_truthy_from_value("off", true));
         assert!(super::env_truthy_from_value("true", false));
-        assert!(super::env_truthy_from_value("", true));
+        assert!(!super::env_truthy_from_value("", true));
     }
 
     #[test]
+    #[serial]
     fn cookie_selection_env_skips_sources_when_cookies_disabled() {
         let previous = env::var("YT_DLP_ENABLE_BROWSER_COOKIES").ok();
         unsafe {


### PR DESCRIPTION
## Summary
- Bump yt-dlp to 2026.6.9 and sync bundled Python from `requirements.txt` on each local nightly run
- Auto-close stale `nightly-failure` and `yt-dlp-update` issues when checks pass
- Honor `YT_DLP_ENABLE_BROWSER_COOKIES=false` when the app sends cookie selection (no longer forces cookies on)

## Test plan
- [ ] `pnpm test:python` passes
- [ ] `RUN_REAL_WORLD_TESTS=1 pnpm test:python:realworld` passes with bundled yt-dlp 2026.6.9
- [ ] Local nightly script closes open `nightly-failure` issues after a successful run
- [ ] Nightly workflow closes `yt-dlp-update` issues when pin matches PyPI latest
- [ ] `YT_DLP_ENABLE_BROWSER_COOKIES=false` disables cookie attempts even with UI cookie selection
- [ ] `cargo test cookie_selection_env` passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cookie handling for downloads, with more reliable behavior when browser cookies are enabled or disabled.
* **Bug Fixes**
  * Fixed cases where cookie-related settings could be applied inconsistently.
  * Updated the bundled `yt-dlp` version to a newer release.
* **Tests**
  * Added coverage for cookie setting behavior and environment variable handling.
* **Chores**
  * Nightly automation now better tracks and closes resolved update and failure issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->