### PR TITLE
feat: accept H:MM:SS section times

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -952,7 +952,6 @@ export default function App() {
 											placeholder={
 												index === 0 ? "0 or 0:00:00" : "e.g. 1:24:40"
 											}
-											inputMode="numeric"
 											autoComplete="off"
 											spellCheck={false}
 											className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -986,7 +985,6 @@ export default function App() {
 													? "e.g. 1:30:00"
 													: "Empty = end of video"
 											}
-											inputMode="numeric"
 											autoComplete="off"
 											spellCheck={false}
 											className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -10,6 +10,7 @@ import {
 } from "./lib/cookie-selection.js";
 import {
 	createSection,
+	parseTimestamp,
 	type Section,
 	type SectionTimeField,
 	updateSectionTime,
@@ -373,6 +374,30 @@ export default function App() {
 					globalCookieSelection,
 				);
 
+	const parseSectionTime = (
+		value: string,
+		fieldLabel: string,
+		sectionNumber: number,
+	): { seconds: number | null; error: string | null } => {
+		try {
+			const seconds = parseTimestamp(value);
+			if (seconds !== null && seconds < 0) {
+				return {
+					seconds: null,
+					error: `${fieldLabel} of section ${sectionNumber} must be non-negative`,
+				};
+			}
+			return { seconds, error: null };
+		} catch (error) {
+			const detail =
+				error instanceof Error ? error.message : "Invalid time format";
+			return {
+				seconds: null,
+				error: `${fieldLabel} of section ${sectionNumber}: ${detail}`,
+			};
+		}
+	};
+
 	const validateSections = (): string | null => {
 		// At least one section required
 		if (sections.length === 0) {
@@ -382,10 +407,16 @@ export default function App() {
 		// Validate each section
 		for (let i = 0; i < sections.length; i++) {
 			const section = sections[i];
-			const start = section.start.trim()
-				? parseInt(section.start.trim(), 10)
-				: null;
-			const end = section.end.trim() ? parseInt(section.end.trim(), 10) : null;
+			const startResult = parseSectionTime(section.start, "Start time", i + 1);
+			if (startResult.error) {
+				return startResult.error;
+			}
+			const endResult = parseSectionTime(section.end, "End time", i + 1);
+			if (endResult.error) {
+				return endResult.error;
+			}
+			const start = startResult.seconds;
+			const end = endResult.seconds;
 
 			// Start time of subsequent sections cannot be empty
 			if (i > 0 && start === null) {
@@ -399,22 +430,6 @@ export default function App() {
 				} cannot be empty (it has a next section)`;
 			}
 
-			// Validate start time if provided
-			if (start !== null) {
-				if (Number.isNaN(start) || start < 0) {
-					return `Start time of section ${
-						i + 1
-					} must be a valid positive number`;
-				}
-			}
-
-			// Validate end time if provided
-			if (end !== null) {
-				if (Number.isNaN(end) || end < 0) {
-					return `End time of section ${i + 1} must be a valid positive number`;
-				}
-			}
-
 			// Validate start < end within section
 			if (start !== null && end !== null && start >= end) {
 				return `End time must be greater than start time in section ${i + 1}`;
@@ -423,22 +438,34 @@ export default function App() {
 			// Validate ordering: next section's start must not be before current section's end
 			if (i < sections.length - 1) {
 				const nextSection = sections[i + 1];
-				const nextStart = nextSection.start.trim()
-					? parseInt(nextSection.start.trim(), 10)
-					: null;
+				const nextStartResult = parseSectionTime(
+					nextSection.start,
+					"Start time",
+					i + 2,
+				);
+				if (nextStartResult.error) {
+					return nextStartResult.error;
+				}
+				const nextStart = nextStartResult.seconds;
 
 				if (end !== null && nextStart !== null && nextStart < end) {
 					return `Start time of section ${
 						i + 2
-					} (${nextStart}s) cannot be before end time of section ${
+					} (${nextSection.start.trim()}) cannot be before end time of section ${
 						i + 1
-					} (${end}s)`;
+					} (${section.end.trim()})`;
 				}
 			}
 		}
 
 		return null;
 	};
+
+	const sectionsToApiPayload = () =>
+		sections.map((s) => ({
+			start: parseTimestamp(s.start),
+			end: parseTimestamp(s.end),
+		}));
 
 	const handleChooseFile = async () => {
 		try {
@@ -516,16 +543,10 @@ export default function App() {
 					setStatusSynced("error");
 					return;
 				}
-				// Convert sections to format expected by backend
-				const sectionsArray = sections.map((s) => ({
-					start: s.start.trim() ? parseInt(s.start.trim(), 10) : null,
-					end: s.end.trim() ? parseInt(s.end.trim(), 10) : null,
-				}));
-
 				const result = await tauriAPI.processLocalVideo({
 					inputPath: localFile,
 					savePath: dialogResult.filePath,
-					sections: sectionsArray,
+					sections: sectionsToApiPayload(),
 				});
 
 				setStatusSynced("completed");
@@ -574,16 +595,10 @@ export default function App() {
 				setStatusSynced("downloading");
 				setProgressSynced(0);
 
-				// Convert sections to format expected by backend
-				const sectionsArray = sections.map((s) => ({
-					start: s.start.trim() ? parseInt(s.start.trim(), 10) : null,
-					end: s.end.trim() ? parseInt(s.end.trim(), 10) : null,
-				}));
-
 				const result = await tauriAPI.downloadVideo({
 					url: url.trim(),
 					savePath,
-					sections: sectionsArray,
+					sections: sectionsToApiPayload(),
 					cookieSelection: submitCookieSelection,
 				});
 
@@ -909,6 +924,9 @@ export default function App() {
 									+ Add Section
 								</button>
 							</div>
+							<p className="text-xs text-gray-500">
+								Times accept seconds, MM:SS, or H:MM:SS (e.g. 90, 1:30, 1:24:40)
+							</p>
 
 							{sections.map((section, index) => (
 								<div
@@ -920,20 +938,23 @@ export default function App() {
 											htmlFor={`startTime-${index}`}
 											className="block text-sm font-medium text-gray-700 mb-2"
 										>
-											Start Time (seconds){" "}
+											Start Time{" "}
 											{index > 0 && <span className="text-red-500">*</span>}
 										</label>
 										<input
-											type="number"
+											type="text"
 											id={`startTime-${index}`}
 											name={`startTime-${index}`}
 											value={section.start}
 											onChange={(e) =>
 												updateSection(index, "start", e.target.value)
 											}
-											placeholder={index === 0 ? "0" : "Required"}
-											min="0"
-											step="1"
+											placeholder={
+												index === 0 ? "0 or 0:00:00" : "e.g. 1:24:40"
+											}
+											inputMode="numeric"
+											autoComplete="off"
+											spellCheck={false}
 											className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 											disabled={
 												status === "extracting" || status === "downloading"
@@ -947,13 +968,13 @@ export default function App() {
 											htmlFor={`endTime-${index}`}
 											className="block text-sm font-medium text-gray-700 mb-2"
 										>
-											End Time (seconds){" "}
+											End Time{" "}
 											{index < sections.length - 1 && (
 												<span className="text-red-500">*</span>
 											)}
 										</label>
 										<input
-											type="number"
+											type="text"
 											id={`endTime-${index}`}
 											name={`endTime-${index}`}
 											value={section.end}
@@ -962,11 +983,12 @@ export default function App() {
 											}
 											placeholder={
 												index < sections.length - 1
-													? "Required"
-													: "Leave empty for end of video"
+													? "e.g. 1:30:00"
+													: "Empty = end of video"
 											}
-											min="0"
-											step="1"
+											inputMode="numeric"
+											autoComplete="off"
+											spellCheck={false}
 											className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
 											disabled={
 												status === "extracting" || status === "downloading"

--- a/app/lib/sections.test.ts
+++ b/app/lib/sections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createSection, updateSectionTime } from "./sections.js";
+import {
+	createSection,
+	parseTimestamp,
+	updateSectionTime,
+} from "./sections.js";
 
 describe("section helpers", () => {
 	it("keeps section identity stable when editing times", () => {
@@ -35,5 +39,42 @@ describe("section helpers", () => {
 		const sections = [createSection("section-0")];
 
 		expect(updateSectionTime(sections, 2, "start", "1")).toBe(sections);
+	});
+});
+
+describe("parseTimestamp", () => {
+	it("returns null for empty input", () => {
+		expect(parseTimestamp("")).toBeNull();
+		expect(parseTimestamp("   ")).toBeNull();
+	});
+
+	it("parses plain seconds", () => {
+		expect(parseTimestamp("0")).toBe(0);
+		expect(parseTimestamp("90")).toBe(90);
+		expect(parseTimestamp("5080")).toBe(5080);
+	});
+
+	it("parses MM:SS", () => {
+		expect(parseTimestamp("1:30")).toBe(90);
+		expect(parseTimestamp("0:40")).toBe(40);
+		expect(parseTimestamp("24:40")).toBe(1480);
+	});
+
+	it("parses H:MM:SS", () => {
+		expect(parseTimestamp("1:24:40")).toBe(5080);
+		expect(parseTimestamp("0:01:30")).toBe(90);
+		expect(parseTimestamp("2:00:00")).toBe(7200);
+	});
+
+	it("rejects invalid formats", () => {
+		expect(() => parseTimestamp("1:60")).toThrow(
+			/Seconds must be between 0 and 59/,
+		);
+		expect(() => parseTimestamp("1:60:00")).toThrow(
+			/Minutes and seconds must be between 0 and 59/,
+		);
+		expect(() => parseTimestamp("1:2:3:4")).toThrow(/Invalid time format/);
+		expect(() => parseTimestamp("abc")).toThrow(/Invalid time format/);
+		expect(() => parseTimestamp("1:aa")).toThrow(/Invalid time format/);
 	});
 });

--- a/app/lib/sections.ts
+++ b/app/lib/sections.ts
@@ -24,3 +24,48 @@ export function updateSectionTime(
 		sectionIndex === index ? { ...section, [field]: value } : section,
 	);
 }
+
+/**
+ * Parse a timestamp to whole seconds.
+ * Accepts plain seconds (`90`), `MM:SS` (`1:30`), or `H:MM:SS` (`1:24:40`).
+ * Returns null for empty input; throws for invalid format.
+ */
+export function parseTimestamp(value: string): number | null {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	if (/^\d+$/.test(trimmed)) {
+		return Number.parseInt(trimmed, 10);
+	}
+
+	const parts = trimmed.split(":");
+	if (parts.length !== 2 && parts.length !== 3) {
+		throw new Error(
+			"Invalid time format. Use seconds, MM:SS, or H:MM:SS (e.g. 90, 1:30, 1:24:40)",
+		);
+	}
+
+	if (parts.some((part) => !/^\d+$/.test(part))) {
+		throw new Error(
+			"Invalid time format. Use seconds, MM:SS, or H:MM:SS (e.g. 90, 1:30, 1:24:40)",
+		);
+	}
+
+	const nums = parts.map((part) => Number.parseInt(part, 10));
+
+	if (nums.length === 2) {
+		const [minutes, seconds] = nums;
+		if (seconds >= 60) {
+			throw new Error("Seconds must be between 0 and 59");
+		}
+		return minutes * 60 + seconds;
+	}
+
+	const [hours, minutes, seconds] = nums;
+	if (minutes >= 60 || seconds >= 60) {
+		throw new Error("Minutes and seconds must be between 0 and 59");
+	}
+	return hours * 3600 + minutes * 60 + seconds;
+}

--- a/python/downloader.py
+++ b/python/downloader.py
@@ -78,6 +78,55 @@ YT_DLP_PRESET_ALIASES = {
 }
 
 
+def parse_timestamp(value: int | float | str | None) -> int | None:
+    """Convert a timestamp to whole seconds for ffmpeg.
+
+    Accepts plain seconds (90), MM:SS ("1:30"), or H:MM:SS ("1:24:40").
+    Empty/None returns None. Invalid values raise ValueError.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("Invalid time format")
+    if isinstance(value, (int, float)):
+        if value < 0 or int(value) != value:
+            raise ValueError("Time must be a non-negative whole number of seconds")
+        return int(value)
+
+    trimmed = str(value).strip()
+    if not trimmed:
+        return None
+
+    if re.fullmatch(r"\d+", trimmed):
+        return int(trimmed)
+
+    parts = trimmed.split(":")
+    if len(parts) not in (2, 3):
+        raise ValueError("Invalid time format. Use seconds, MM:SS, or H:MM:SS (e.g. 90, 1:30, 1:24:40)")
+
+    if not all(re.fullmatch(r"\d+", part) for part in parts):
+        raise ValueError("Invalid time format. Use seconds, MM:SS, or H:MM:SS (e.g. 90, 1:30, 1:24:40)")
+
+    nums = [int(part) for part in parts]
+    if len(nums) == 2:
+        minutes, seconds = nums
+        if seconds >= 60:
+            raise ValueError("Seconds must be between 0 and 59")
+        return minutes * 60 + seconds
+
+    hours, minutes, seconds = nums
+    if minutes >= 60 or seconds >= 60:
+        raise ValueError("Minutes and seconds must be between 0 and 59")
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def parse_section_times(section: object) -> tuple[int | None, int | None]:
+    """Parse a section dict into (start_seconds, end_seconds)."""
+    if not isinstance(section, dict):
+        return None, None
+    return parse_timestamp(section.get("start")), parse_timestamp(section.get("end"))
+
+
 @dataclass
 class VideoInfo:
     """Video information extracted from YouTube"""
@@ -3036,15 +3085,16 @@ def main():
                 try:
                     parsed_sections = json.loads(sections_json)
                     if isinstance(parsed_sections, list):
-                        sections = [
-                            (
-                                section.get("start") if isinstance(section, dict) else None,
-                                section.get("end") if isinstance(section, dict) else None,
-                            )
-                            for section in parsed_sections
-                        ]
-                except json.JSONDecodeError:
-                    sys.stdout.write(json.dumps({"success": False, "error_message": "Invalid sections JSON"}))
+                        sections = [parse_section_times(section) for section in parsed_sections]
+                except (json.JSONDecodeError, ValueError, TypeError) as e:
+                    sys.stdout.write(
+                        json.dumps(
+                            {
+                                "success": False,
+                                "error_message": f"Invalid sections: {str(e)}",
+                            }
+                        )
+                    )
                     sys.stdout.flush()
                     sys.exit(1)
 
@@ -3162,13 +3212,7 @@ def main():
                     parsed_sections = json.loads(arg4)
                     if isinstance(parsed_sections, list) and len(parsed_sections) > 0:
                         # Convert to list of tuples
-                        sections = [
-                            (
-                                section.get("start") if isinstance(section, dict) else None,
-                                section.get("end") if isinstance(section, dict) else None,
-                            )
-                            for section in parsed_sections
-                        ]
+                        sections = [parse_section_times(section) for section in parsed_sections]
                     else:
                         sys.stdout.write(
                             json.dumps(
@@ -3194,9 +3238,7 @@ def main():
             else:
                 # Not JSON, treat as legacy format (single start_time)
                 try:
-                    start_time = int(arg4)
-                    if start_time < 0:
-                        start_time = None
+                    start_time = parse_timestamp(arg4)
                 except (ValueError, TypeError):
                     start_time = None
                 # In this case, output_path is already set from sys.argv[-1]
@@ -3204,17 +3246,13 @@ def main():
         # Legacy format: arg4 is start_time, arg5 is end_time
         if len(sys.argv) > 4 and sys.argv[4] and sys.argv[4].strip():
             try:
-                start_time = int(sys.argv[4])
-                if start_time < 0:
-                    start_time = None
+                start_time = parse_timestamp(sys.argv[4])
             except (ValueError, TypeError):
                 start_time = None
 
         if len(sys.argv) > 5 and sys.argv[5] and sys.argv[5].strip():
             try:
-                end_time = int(sys.argv[5])
-                if end_time < 0:
-                    end_time = None
+                end_time = parse_timestamp(sys.argv[5])
             except (ValueError, TypeError):
                 end_time = None
 

--- a/python/downloader.py
+++ b/python/downloader.py
@@ -123,7 +123,7 @@ def parse_timestamp(value: int | float | str | None) -> int | None:
 def parse_section_times(section: object) -> tuple[int | None, int | None]:
     """Parse a section dict into (start_seconds, end_seconds)."""
     if not isinstance(section, dict):
-        return None, None
+        raise ValueError("Each section must be an object")
     return parse_timestamp(section.get("start")), parse_timestamp(section.get("end"))
 
 
@@ -3084,8 +3084,9 @@ def main():
             if sections_json and sections_json.strip() and sections_json != "[]":
                 try:
                     parsed_sections = json.loads(sections_json)
-                    if isinstance(parsed_sections, list):
-                        sections = [parse_section_times(section) for section in parsed_sections]
+                    if not isinstance(parsed_sections, list):
+                        raise ValueError("Invalid sections format: empty list or not a list")
+                    sections = [parse_section_times(section) for section in parsed_sections]
                 except (json.JSONDecodeError, ValueError, TypeError) as e:
                     sys.stdout.write(
                         json.dumps(
@@ -3239,22 +3240,28 @@ def main():
                 # Not JSON, treat as legacy format (single start_time)
                 try:
                     start_time = parse_timestamp(arg4)
-                except (ValueError, TypeError):
-                    start_time = None
+                except (ValueError, TypeError) as e:
+                    sys.stdout.write(json.dumps({"success": False, "error": f"Invalid start_time: {e}"}))
+                    sys.stdout.flush()
+                    sys.exit(1)
                 # In this case, output_path is already set from sys.argv[-1]
     elif len(sys.argv) >= 7:
         # Legacy format: arg4 is start_time, arg5 is end_time
         if len(sys.argv) > 4 and sys.argv[4] and sys.argv[4].strip():
             try:
                 start_time = parse_timestamp(sys.argv[4])
-            except (ValueError, TypeError):
-                start_time = None
+            except (ValueError, TypeError) as e:
+                sys.stdout.write(json.dumps({"success": False, "error": f"Invalid start_time: {e}"}))
+                sys.stdout.flush()
+                sys.exit(1)
 
         if len(sys.argv) > 5 and sys.argv[5] and sys.argv[5].strip():
             try:
                 end_time = parse_timestamp(sys.argv[5])
-            except (ValueError, TypeError):
-                end_time = None
+            except (ValueError, TypeError) as e:
+                sys.stdout.write(json.dumps({"success": False, "error": f"Invalid end_time: {e}"}))
+                sys.stdout.flush()
+                sys.exit(1)
 
     if not output_path:
         sys.stdout.write(json.dumps({"success": False, "error": "Output path is required"}))

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -22,6 +22,8 @@ from downloader import (
     DownloadResult,
     VideoInfo,
     YouTubeDownloader,
+    parse_section_times,
+    parse_timestamp,
 )
 
 # ============================================================================
@@ -129,6 +131,48 @@ def mock_shutil_which():
 # ============================================================================
 # Dataclass Tests
 # ============================================================================
+
+
+# ============================================================================
+# parse_timestamp
+# ============================================================================
+
+
+class TestParseTimestamp:
+    def test_none_and_empty(self):
+        assert parse_timestamp(None) is None
+        assert parse_timestamp("") is None
+        assert parse_timestamp("   ") is None
+
+    def test_plain_seconds(self):
+        assert parse_timestamp(0) == 0
+        assert parse_timestamp(90) == 90
+        assert parse_timestamp("5080") == 5080
+
+    def test_mm_ss(self):
+        assert parse_timestamp("1:30") == 90
+        assert parse_timestamp("0:40") == 40
+        assert parse_timestamp("24:40") == 1480
+
+    def test_h_mm_ss(self):
+        assert parse_timestamp("1:24:40") == 5080
+        assert parse_timestamp("0:01:30") == 90
+        assert parse_timestamp("2:00:00") == 7200
+
+    def test_rejects_invalid(self):
+        with pytest.raises(ValueError, match="Seconds must be between 0 and 59"):
+            parse_timestamp("1:60")
+        with pytest.raises(ValueError, match="Minutes and seconds must be between 0 and 59"):
+            parse_timestamp("1:60:00")
+        with pytest.raises(ValueError, match="Invalid time format"):
+            parse_timestamp("abc")
+        with pytest.raises(ValueError, match="non-negative"):
+            parse_timestamp(-1)
+
+    def test_parse_section_times(self):
+        assert parse_section_times({"start": "1:24:40", "end": "2:00:00"}) == (5080, 7200)
+        assert parse_section_times({"start": 10, "end": None}) == (10, None)
+        assert parse_section_times("not-a-dict") == (None, None)
 
 
 class TestVideoInfo:

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -172,7 +172,8 @@ class TestParseTimestamp:
     def test_parse_section_times(self):
         assert parse_section_times({"start": "1:24:40", "end": "2:00:00"}) == (5080, 7200)
         assert parse_section_times({"start": 10, "end": None}) == (10, None)
-        assert parse_section_times("not-a-dict") == (None, None)
+        with pytest.raises(ValueError, match="Each section must be an object"):
+            parse_section_times("not-a-dict")
 
 
 class TestVideoInfo:


### PR DESCRIPTION
## Summary
- Start/End time inputs accept seconds, `MM:SS`, or `H:MM:SS` (e.g. `1:24:40`) instead of requiring raw seconds
- Frontend validates and converts to seconds for the existing Tauri API
- Python `parse_timestamp` converts the same formats when parsing section JSON / CLI args for ffmpeg

## Test plan
- [ ] Enter start `1:24:40` and end `1:30:00`, confirm cut uses those times
- [ ] Enter plain seconds (`90`) still works
- [ ] Enter `MM:SS` (`1:30`) still works
- [ ] Invalid times (`1:60`, `abc`) show a clear validation error
- [ ] Multi-section ordering validation still works with timestamp strings


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Section timestamps now support seconds, `MM:SS`, and `H:MM:SS` formats.
  * Section inputs provide updated guidance, placeholders, and text-based entry.
  * Local processing and YouTube downloads use consistent section timing.
  * Clear validation messages identify invalid or out-of-range timestamps.

* **Bug Fixes**
  * Improved handling of empty, malformed, negative, fractional, and incomplete timestamp values.

* **Tests**
  * Added coverage for supported timestamp formats, validation errors, and missing section values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->