### PR TITLE
fix(ci): surface Apple agreement notarization failures

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -120,7 +120,19 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
-        run: pnpm tauri build --target aarch64-apple-darwin --bundles dmg --ci
+        run: |
+          set -euo pipefail
+          set +e
+          pnpm tauri build --target aarch64-apple-darwin --bundles dmg --ci 2>&1 | tee "$RUNNER_TEMP/tauri-macos-build.log"
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -ne 0 ]; then
+            if grep -Eqi 'required agreement is missing or has expired|necessary legal agreements' "$RUNNER_TEMP/tauri-macos-build.log"; then
+              echo "::error::Apple notarization blocked: a Developer/App Store Connect agreement is missing or expired."
+              echo "::error::Account holder/Admin must accept pending agreements at https://developer.apple.com/account and https://appstoreconnect.apple.com/agreements, then re-run this workflow."
+            fi
+            exit "$status"
+          fi
 
       - name: Verify macOS bundle trust
         env:

--- a/BUILD.md
+++ b/BUILD.md
@@ -81,3 +81,6 @@ After `pnpm install`, lefthook installs git hooks; pre-commit formats staged fil
 - Run `node scripts/prebuild.js` to ensure resource folders exist.
 - Run `pnpm typecheck` and `source $HOME/.cargo/env && cargo test` in `src-tauri`.
 - See `DEBUGGING.md` for log retrieval and common failures.
+- macOS release notarization `HTTP 403` / "required agreement is missing or has expired":
+  - Signing secrets are fine; Apple is rejecting notarization until legal agreements are accepted.
+  - Account holder/Admin: accept pending agreements at [developer.apple.com/account](https://developer.apple.com/account) and [appstoreconnect.apple.com/agreements](https://appstoreconnect.apple.com/agreements), wait a few minutes, re-run `tauri-release.yml`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`v2.3.0` release failed on macOS only: notarization returned HTTP 403 because an Apple Developer / App Store Connect agreement is missing or expired. Linux + Windows builds succeeded; signing secrets imported fine.

**Unblock (required):** account holder for team `V2AF2874XA` must accept pending agreements at [developer.apple.com/account](https://developer.apple.com/account) and [appstoreconnect.apple.com/agreements](https://appstoreconnect.apple.com/agreements), then re-run Tauri Release for `v2.3.0`.

## This PR

- Detect that notarization agreement error in `tauri-release.yml` and emit actionable `::error` annotations
- Document the failure mode in `BUILD.md`

No secret or packaging logic changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd964-57ed-71ae-9259-191b2de3b0ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd964-57ed-71ae-9259-191b2de3b0ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release build failures by identifying missing or expired Apple agreements and displaying actionable guidance.
  * Preserved accurate build failure reporting when notarization issues occur.

* **Documentation**
  * Added troubleshooting guidance for macOS notarization errors, including how to resolve HTTP 403 responses and rerun the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->