### PR TITLE
fix: honor requested video start time

### DIFF
--- a/app/lib/tauri-api.ts
+++ b/app/lib/tauri-api.ts
@@ -94,7 +94,7 @@ export const tauriAPI = {
 		const filePath = await save({
 			defaultPath,
 			filters: [
-				{ name: "Video Files", extensions: ["mp4", "webm", "mkv"] },
+				{ name: "Video Files", extensions: ["mp4", "webm", "mkv", "mov"] },
 				{ name: "All Files", extensions: ["*"] },
 			],
 		});

--- a/python/downloader.py
+++ b/python/downloader.py
@@ -2096,15 +2096,15 @@ class YouTubeDownloader:
             )
             return False
 
-        # Stream-copying can only seek to a preceding keyframe. A section that
-        # starts between keyframes can therefore include the beginning of the
-        # source video, which makes the requested start time ineffective.
-        # Decode before seeking and encode the result so section boundaries are
-        # frame-accurate.
-        cmd = [ffmpeg_path, "-i", str(input_path)]
-
+        # Stream-copying can only seek to a preceding keyframe. Re-encoding
+        # lets FFmpeg decode from that keyframe through the requested start,
+        # producing frame-accurate section boundaries while retaining fast
+        # input seeking for late sections.
+        cmd = [ffmpeg_path]
         if start_time is not None:
             cmd.extend(["-ss", str(start_time)])
+
+        cmd.extend(["-i", str(input_path)])
 
         if end_time is not None:
             # Calculate duration: if start_time is None, duration is just end_time
@@ -2121,9 +2121,11 @@ class YouTubeDownloader:
                 return False
             cmd.extend(["-t", str(duration)])
 
-        cmd.extend(["-map", "0:v:0", "-map", "0:a?"])
+        output_extension = Path(output_path).suffix.lower()
+        cmd.extend(["-map", "0:v:0?", "-map", "0:a:0?"])
 
-        if Path(output_path).suffix.lower() == ".webm":
+        if output_extension == ".webm":
+            cmd.extend(["-map", "0:s?"])
             cmd.extend(
                 [
                     "-c:v",
@@ -2136,9 +2138,13 @@ class YouTubeDownloader:
                     "libopus",
                     "-b:a",
                     "192k",
+                    "-c:s",
+                    "webvtt",
                 ]
             )
         else:
+            if output_extension in (".mkv", ".mp4", ".m4v", ".mov"):
+                cmd.extend(["-map", "0:s?"])
             cmd.extend(
                 [
                     "-c:v",
@@ -2147,6 +2153,8 @@ class YouTubeDownloader:
                     "medium",
                     "-crf",
                     "18",
+                    "-vf",
+                    "pad=ceil(iw/2)*2:ceil(ih/2)*2",
                     "-pix_fmt",
                     "yuv420p",
                     "-c:a",
@@ -2155,6 +2163,10 @@ class YouTubeDownloader:
                     "192k",
                 ]
             )
+            if output_extension == ".mkv":
+                cmd.extend(["-c:s", "copy"])
+            elif output_extension in (".mp4", ".m4v", ".mov"):
+                cmd.extend(["-c:s", "mov_text"])
 
         cmd.extend([str(output_path), "-y"])
 
@@ -2375,9 +2387,18 @@ class YouTubeDownloader:
                 video_info=video_info,
             )
 
-        # Check if we need to cut the video
-        # Use sections if provided, otherwise fall back to single start/end time
-        if sections and len(sections) > 0:
+        # A blank initial UI section serializes as [(None, None)]. It is not a
+        # requested cut, so leave the download lossless and avoid a needless
+        # full-video transcode.
+        bounded_sections = [
+            (section_start, section_end)
+            for section_start, section_end in (sections or [])
+            if section_start is not None or section_end is not None
+        ]
+
+        # Check if we need to cut the video. Use non-blank sections if
+        # provided, otherwise fall back to the legacy single start/end pair.
+        if bounded_sections:
             needs_cut = True
             use_sections = True
         else:
@@ -2904,7 +2925,7 @@ class YouTubeDownloader:
             if use_sections:
                 if not self.cut_and_concatenate_sections(
                     str(original_file_path),
-                    sections or [],
+                    bounded_sections,
                     str(temp_processing_file),
                     video_info.id,
                 ):

--- a/python/downloader.py
+++ b/python/downloader.py
@@ -1634,17 +1634,17 @@ class YouTubeDownloader:
         return None
 
     @staticmethod
-    def _is_quicktime_video_codec(codec: str | None) -> bool:
+    def _is_quicktime_video_codec(codec: str | None, target_extension: str = ".mp4") -> bool:
         normalized = str(codec or "").strip().lower()
         if normalized in ("", "none"):
             return True
-        return (
+        is_h264_or_hevc = (
             normalized.startswith("avc1")
             or normalized.startswith("h264")
             or normalized.startswith("hevc")
             or normalized.startswith("h265")
-            or normalized.startswith("prores")
         )
+        return is_h264_or_hevc or (target_extension == ".mov" and normalized.startswith("prores"))
 
     @staticmethod
     def _is_quicktime_audio_codec(codec: str | None) -> bool:
@@ -1671,7 +1671,8 @@ class YouTubeDownloader:
         if source_ext not in (".mp4", ".m4v", ".mov"):
             return True
 
-        if not YouTubeDownloader._is_quicktime_video_codec(source_video_codec):
+        target_extension = output_path.suffix.lower()
+        if not YouTubeDownloader._is_quicktime_video_codec(source_video_codec, target_extension):
             return True
 
         if not YouTubeDownloader._is_quicktime_audio_codec(source_audio_codec):
@@ -1681,7 +1682,7 @@ class YouTubeDownloader:
             return False
 
         video_codec = str(selected_format.get("vcodec") or "").strip().lower()
-        if not YouTubeDownloader._is_quicktime_video_codec(video_codec):
+        if not YouTubeDownloader._is_quicktime_video_codec(video_codec, target_extension):
             return True
 
         audio_codec = str(selected_format.get("acodec") or "").strip().lower()
@@ -1830,9 +1831,9 @@ class YouTubeDownloader:
                     "-select_streams",
                     "v",
                     "-show_entries",
-                    "stream=pix_fmt",
+                    "stream=pix_fmt:stream_tags=alpha_mode",
                     "-of",
-                    "default=nw=1:nk=1",
+                    "json",
                     str(input_path),
                 ],
                 capture_output=True,
@@ -1840,15 +1841,64 @@ class YouTubeDownloader:
                 check=False,
                 timeout=15,
             )
-            if not isinstance(result.stdout, str):
+            if result.returncode != 0 or not isinstance(result.stdout, str):
                 return False
-            pixel_formats = result.stdout.lower().splitlines()
+            payload = json.loads(result.stdout)
+            streams = payload.get("streams") or []
             return any(
-                pixel_format.startswith(("yuva", "rgba", "bgra", "argb", "abgr", "gbrap"))
-                for pixel_format in pixel_formats
+                isinstance(stream, dict)
+                and (
+                    str(stream.get("pix_fmt") or "")
+                    .lower()
+                    .startswith(("yuva", "rgba", "bgra", "argb", "abgr", "gbrap"))
+                    or str((stream.get("tags") or {}).get("alpha_mode") or "").lower() in ("1", "true", "yes")
+                )
+                for stream in streams
             )
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError, TypeError):
             return False
+
+    def _text_subtitle_map_args(self, input_path: Path, output_extension: str) -> list[str]:
+        """Map only subtitles that FFmpeg can safely encode as text."""
+        if output_extension == ".mkv":
+            return ["-map", "0:s?"]
+        if output_extension not in (".mp4", ".m4v", ".mov", ".webm"):
+            return []
+
+        ffprobe_path = self._resolve_ffprobe_path()
+        if not ffprobe_path:
+            return []
+        try:
+            result = subprocess.run(
+                [
+                    ffprobe_path,
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "s",
+                    "-show_entries",
+                    "stream=codec_name",
+                    "-of",
+                    "json",
+                    str(input_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            )
+            if result.returncode != 0 or not isinstance(result.stdout, str):
+                return []
+            streams = json.loads(result.stdout).get("streams") or []
+            text_codecs = {"ass", "mov_text", "ssa", "subrip", "text", "webvtt"}
+            return [
+                item
+                for index, stream in enumerate(streams)
+                if isinstance(stream, dict) and str(stream.get("codec_name") or "").lower() in text_codecs
+                for item in ("-map", f"0:s:{index}?")
+            ]
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError, TypeError):
+            return []
 
     def _remux_copy(self, input_path: Path, output_path: Path, output_format: str | None = None) -> bool:
         ffmpeg_path = self._resolve_ffmpeg_location_for_ytdlp()
@@ -2177,10 +2227,12 @@ class YouTubeDownloader:
             print("MP4 output cannot preserve video transparency; save as .mov, .mkv, or .webm", file=sys.stderr)
             return False
 
-        # Preserve every intended video/audio/subtitle track rather than
-        # forcing the first stream of each type. This also supports audio-only
-        # inputs, which have no video stream to map.
-        cmd.extend(["-map", "0:v?", "-map", "0:a?", "-map", "0:s?"])
+        # Preserve every intended video/audio track rather than forcing the
+        # first stream of each type. This also supports audio-only inputs.
+        # Text subtitles are selected separately so bitmap subtitles never
+        # make text-only MP4/MOV/WebM encoders fail the whole cut.
+        cmd.extend(["-map", "0:v?", "-map", "0:a?"])
+        cmd.extend(self._text_subtitle_map_args(input_path_obj, output_extension))
 
         if output_extension == ".webm":
             cmd.extend(

--- a/python/downloader.py
+++ b/python/downloader.py
@@ -1643,6 +1643,7 @@ class YouTubeDownloader:
             or normalized.startswith("h264")
             or normalized.startswith("hevc")
             or normalized.startswith("h265")
+            or normalized.startswith("prores")
         )
 
     @staticmethod
@@ -1662,8 +1663,8 @@ class YouTubeDownloader:
         source_video_codec: str | None = None,
         source_audio_codec: str | None = None,
     ) -> bool:
-        """Decide whether final .mp4 should be transcoded for QuickTime compatibility."""
-        if output_path.suffix.lower() != ".mp4":
+        """Decide whether final MP4/MOV should be transcoded for QuickTime compatibility."""
+        if output_path.suffix.lower() not in (".mp4", ".mov"):
             return False
 
         source_ext = source_path.suffix.lower()
@@ -1795,11 +1796,59 @@ class YouTubeDownloader:
             pass
 
     @staticmethod
-    def _temp_processing_extension(source_path: Path) -> str:
+    def _bounded_sections(
+        sections: list[tuple[int | None, int | None]] | None,
+    ) -> list[tuple[int | None, int | None]]:
+        """Discard empty UI placeholder sections that do not request a cut."""
+        return [
+            (start_time, end_time)
+            for start_time, end_time in (sections or [])
+            if start_time is not None or end_time is not None
+        ]
+
+    @staticmethod
+    def _temp_processing_extension(source_path: Path, output_path: Path | None = None) -> str:
+        """Choose an intermediate container compatible with the requested output."""
+        if output_path and output_path.suffix.lower() in (".mp4", ".mkv", ".webm", ".mov"):
+            return output_path.suffix.lower()
         ext = source_path.suffix.lower()
         if ext in (".mp4", ".m4v", ".mov", ".mkv", ".webm"):
             return ext
         return ".mkv"
+
+    def _input_has_alpha(self, input_path: Path) -> bool:
+        """Detect whether any video stream has an alpha channel."""
+        ffprobe_path = self._resolve_ffprobe_path()
+        if not ffprobe_path:
+            return False
+        try:
+            result = subprocess.run(
+                [
+                    ffprobe_path,
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v",
+                    "-show_entries",
+                    "stream=pix_fmt",
+                    "-of",
+                    "default=nw=1:nk=1",
+                    str(input_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            )
+            if not isinstance(result.stdout, str):
+                return False
+            pixel_formats = result.stdout.lower().splitlines()
+            return any(
+                pixel_format.startswith(("yuva", "rgba", "bgra", "argb", "abgr", "gbrap"))
+                for pixel_format in pixel_formats
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
 
     def _remux_copy(self, input_path: Path, output_path: Path, output_format: str | None = None) -> bool:
         ffmpeg_path = self._resolve_ffmpeg_location_for_ytdlp()
@@ -1962,7 +2011,7 @@ class YouTubeDownloader:
             )
             return True, None
 
-        if target_ext == ".mp4":
+        if target_ext in (".mp4", ".mov"):
             source_video_codec, source_audio_codec = self._probe_primary_stream_codecs(source_path)
             force_compat_transcode = self._is_truthy_env("YT_DLP_ENABLE_MP4_COMPAT_TRANSCODE", default=False)
             requires_compat_transcode = force_compat_transcode or self._requires_mp4_compatibility_transcode(
@@ -1989,7 +2038,7 @@ class YouTubeDownloader:
                 self._emit_debug_event(
                     "quality_debug",
                     {
-                        "event": "mp4_compat_transcode",
+                        "event": "quicktime_compat_transcode",
                         "input_path": str(source_path),
                         "output_path": str(output_path),
                         "source_ext": source_ext,
@@ -2008,21 +2057,21 @@ class YouTubeDownloader:
                     "quality_debug",
                     {
                         "event": "output_normalized",
-                        "action": "transcode_mp4",
+                        "action": "transcode_quicktime",
                         "source_ext": source_ext,
                         "target_ext": target_ext,
                     },
                 )
                 return True, None
 
-            if source_ext == ".mp4":
+            if source_ext == target_ext:
                 try:
                     shutil.copy2(str(source_path), str(output_path))
                     self._emit_debug_event(
                         "quality_debug",
                         {
                             "event": "output_normalized",
-                            "action": "copy_mp4",
+                            "action": "copy_quicktime",
                             "source_ext": source_ext,
                             "target_ext": target_ext,
                         },
@@ -2031,13 +2080,14 @@ class YouTubeDownloader:
                 except (OSError, PermissionError) as e:
                     return False, f"Failed to copy file to requested location: {str(e)}"
 
-            if not self._remux_copy(source_path, output_path, output_format="mp4"):
-                return False, "Failed to remux downloaded file into MP4 container."
+            output_format = "mov" if target_ext == ".mov" else "mp4"
+            if not self._remux_copy(source_path, output_path, output_format=output_format):
+                return False, f"Failed to remux downloaded file into {target_ext.upper()} container."
             self._emit_debug_event(
                 "quality_debug",
                 {
                     "event": "output_normalized",
-                    "action": "remux_mp4",
+                    "action": "remux_quicktime",
                     "source_ext": source_ext,
                     "target_ext": target_ext,
                 },
@@ -2062,7 +2112,7 @@ class YouTubeDownloader:
 
         return (
             False,
-            f"Unsupported output format '{target_ext or '(none)'}'. Please save as .mp4, .mkv, or .webm.",
+            f"Unsupported output format '{target_ext or '(none)'}'. Please save as .mp4, .mkv, .webm, or .mov.",
         )
 
     def cut_video(
@@ -2122,10 +2172,17 @@ class YouTubeDownloader:
             cmd.extend(["-t", str(duration)])
 
         output_extension = Path(output_path).suffix.lower()
-        cmd.extend(["-map", "0:v:0?", "-map", "0:a:0?"])
+        has_alpha = self._input_has_alpha(input_path_obj)
+        if has_alpha and output_extension == ".mp4":
+            print("MP4 output cannot preserve video transparency; save as .mov, .mkv, or .webm", file=sys.stderr)
+            return False
+
+        # Preserve every intended video/audio/subtitle track rather than
+        # forcing the first stream of each type. This also supports audio-only
+        # inputs, which have no video stream to map.
+        cmd.extend(["-map", "0:v?", "-map", "0:a?", "-map", "0:s?"])
 
         if output_extension == ".webm":
-            cmd.extend(["-map", "0:s?"])
             cmd.extend(
                 [
                     "-c:v",
@@ -2134,6 +2191,8 @@ class YouTubeDownloader:
                     "30",
                     "-b:v",
                     "0",
+                    "-pix_fmt",
+                    "yuva420p" if has_alpha else "yuv420p",
                     "-c:a",
                     "libopus",
                     "-b:a",
@@ -2142,9 +2201,39 @@ class YouTubeDownloader:
                     "webvtt",
                 ]
             )
+        elif has_alpha and output_extension == ".mov":
+            cmd.extend(
+                [
+                    "-c:v",
+                    "prores_ks",
+                    "-profile:v",
+                    "4",
+                    "-pix_fmt",
+                    "yuva444p10le",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "192k",
+                    "-c:s",
+                    "mov_text",
+                ]
+            )
+        elif has_alpha and output_extension == ".mkv":
+            cmd.extend(
+                [
+                    "-c:v",
+                    "ffv1",
+                    "-pix_fmt",
+                    "rgba",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "192k",
+                    "-c:s",
+                    "copy",
+                ]
+            )
         else:
-            if output_extension in (".mkv", ".mp4", ".m4v", ".mov"):
-                cmd.extend(["-map", "0:s?"])
             cmd.extend(
                 [
                     "-c:v",
@@ -2154,7 +2243,7 @@ class YouTubeDownloader:
                     "-crf",
                     "18",
                     "-vf",
-                    "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+                    "pad=ceil(iw/2)*2:ceil(ih/2)*2:color=black@0",
                     "-pix_fmt",
                     "yuv420p",
                     "-c:a",
@@ -2239,7 +2328,7 @@ class YouTubeDownloader:
         temp_dir = self._get_temp_dir()
         section_files: list[Path] = []
         concat_file: Path | None = None
-        section_ext = (temp_extension or Path(input_path).suffix or ".mkv").strip()
+        section_ext = (temp_extension or Path(output_path).suffix or Path(input_path).suffix or ".mkv").strip()
         if not section_ext.startswith("."):
             section_ext = f".{section_ext}"
 
@@ -2390,11 +2479,7 @@ class YouTubeDownloader:
         # A blank initial UI section serializes as [(None, None)]. It is not a
         # requested cut, so leave the download lossless and avoid a needless
         # full-video transcode.
-        bounded_sections = [
-            (section_start, section_end)
-            for section_start, section_end in (sections or [])
-            if section_start is not None or section_end is not None
-        ]
+        bounded_sections = self._bounded_sections(sections)
 
         # Check if we need to cut the video. Use non-blank sections if
         # provided, otherwise fall back to the legacy single start/end pair.
@@ -2918,7 +3003,7 @@ class YouTubeDownloader:
                     video_info=video_info,
                 )
 
-            cut_ext = self._temp_processing_extension(original_file_path)
+            cut_ext = self._temp_processing_extension(original_file_path, output_path_obj)
             temp_processing_file = temp_dir / f"{cache_video_id}_section_work{cut_ext}"
             self._safe_unlink(temp_processing_file)
 
@@ -2976,7 +3061,10 @@ class YouTubeDownloader:
             normalized, normalize_error = self._normalize_output_file(
                 processing_source,
                 output_path_obj,
-                progress_tracker.selected_format,
+                # Section output has been re-encoded for the requested target
+                # container. Its probe is authoritative; the original yt-dlp
+                # selection would otherwise force a needless second transcode.
+                None if needs_cut else progress_tracker.selected_format,
             )
             final_path_obj = output_path_obj
 
@@ -3144,7 +3232,9 @@ def main():
                     parsed_sections = json.loads(sections_json)
                     if not isinstance(parsed_sections, list):
                         raise ValueError("Invalid sections format: empty list or not a list")
-                    sections = [parse_section_times(section) for section in parsed_sections]
+                    sections = downloader._bounded_sections(
+                        [parse_section_times(section) for section in parsed_sections]
+                    )
                 except (json.JSONDecodeError, ValueError, TypeError) as e:
                     sys.stdout.write(
                         json.dumps(
@@ -3181,7 +3271,7 @@ def main():
                     try:
                         if sections:
                             video_id = "local_video"
-                            temp_ext = downloader._temp_processing_extension(source_path)
+                            temp_ext = downloader._temp_processing_extension(source_path, output_path_obj)
                             temp_processing_file = downloader._get_temp_dir() / f"{video_id}_section_work{temp_ext}"
                             downloader._safe_unlink(temp_processing_file)
                             success = downloader.cut_and_concatenate_sections(
@@ -3189,7 +3279,6 @@ def main():
                                 sections,
                                 str(temp_processing_file),
                                 video_id,
-                                temp_extension=temp_ext,
                             )
                             if not success:
                                 error_message = "Failed to cut and concatenate sections"

--- a/python/downloader.py
+++ b/python/downloader.py
@@ -2096,13 +2096,15 @@ class YouTubeDownloader:
             )
             return False
 
-        cmd = [ffmpeg_path]
+        # Stream-copying can only seek to a preceding keyframe. A section that
+        # starts between keyframes can therefore include the beginning of the
+        # source video, which makes the requested start time ineffective.
+        # Decode before seeking and encode the result so section boundaries are
+        # frame-accurate.
+        cmd = [ffmpeg_path, "-i", str(input_path)]
 
-        # When using -c copy, -ss must be before -i for accurate seeking
         if start_time is not None:
             cmd.extend(["-ss", str(start_time)])
-
-        cmd.extend(["-i", str(input_path), "-c", "copy"])
 
         if end_time is not None:
             # Calculate duration: if start_time is None, duration is just end_time
@@ -2119,7 +2121,42 @@ class YouTubeDownloader:
                 return False
             cmd.extend(["-t", str(duration)])
 
-        cmd.extend(["-avoid_negative_ts", "make_zero", str(output_path), "-y"])
+        cmd.extend(["-map", "0:v:0", "-map", "0:a?"])
+
+        if Path(output_path).suffix.lower() == ".webm":
+            cmd.extend(
+                [
+                    "-c:v",
+                    "libvpx-vp9",
+                    "-crf",
+                    "30",
+                    "-b:v",
+                    "0",
+                    "-c:a",
+                    "libopus",
+                    "-b:a",
+                    "192k",
+                ]
+            )
+        else:
+            cmd.extend(
+                [
+                    "-c:v",
+                    "libx264",
+                    "-preset",
+                    "medium",
+                    "-crf",
+                    "18",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "192k",
+                ]
+            )
+
+        cmd.extend([str(output_path), "-y"])
 
         try:
             subprocess.run(

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -1147,7 +1147,6 @@ class TestCutVideo:
         result = downloader.cut_video(str(input_file), str(output_file), start_time=10)
 
         assert result is True
-        mock_subprocess_run.assert_called_once()
         cmd = mock_subprocess_run.call_args[0][0]
         assert "-ss" in cmd
         assert "10" in cmd
@@ -1195,8 +1194,8 @@ class TestCutVideo:
         assert cmd[cmd.index("-i") + 1] == str(input_file)
         assert "copy" not in cmd
         assert cmd[cmd.index("-c:v") + 1] == "libx264"
-        assert cmd[cmd.index("-map") + 1] == "0:v:0?"
-        assert "pad=ceil(iw/2)*2:ceil(ih/2)*2" in cmd
+        assert cmd[cmd.index("-map") + 1] == "0:v?"
+        assert "pad=ceil(iw/2)*2:ceil(ih/2)*2:color=black@0" in cmd
 
     @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
     def test_cut_video_honors_non_keyframe_start_time(self, temp_dir, monkeypatch):
@@ -1360,6 +1359,75 @@ class TestCutVideo:
         monkeypatch.setenv("FFMPEG_PATH", ffmpeg_path)
 
         assert YouTubeDownloader().cut_video(str(input_file), str(output_file), start_time=1, end_time=2)
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+    def test_cut_video_preserves_alpha_in_mov_output(self, temp_dir, monkeypatch):
+        """Transparency is retained for a container and codec that support it."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        ffprobe_path = shutil.which("ffprobe")
+        assert ffmpeg_path is not None
+        if ffprobe_path is None:
+            pytest.skip("ffprobe is required to verify alpha preservation")
+        input_file = temp_dir / "input.mov"
+        output_file = temp_dir / "output.mov"
+        subprocess.run(
+            [
+                ffmpeg_path,
+                "-f",
+                "lavfi",
+                "-i",
+                "color=red@0.5:size=64x64:rate=5:duration=3",
+                "-vf",
+                "format=rgba",
+                "-c:v",
+                "qtrle",
+                "-pix_fmt",
+                "argb",
+                str(input_file),
+                "-y",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        monkeypatch.setenv("FFMPEG_PATH", ffmpeg_path)
+
+        assert YouTubeDownloader().cut_video(str(input_file), str(output_file), start_time=1, end_time=2)
+
+        pixel_format = subprocess.run(
+            [
+                ffprobe_path,
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=pix_fmt",
+                "-of",
+                "default=nw=1:nk=1",
+                str(output_file),
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.strip()
+        assert pixel_format.startswith("yuva")
+
+    def test_temp_processing_extension_prefers_requested_output_format(self):
+        """A target-compatible intermediate prevents a second final transcode."""
+        assert YouTubeDownloader._temp_processing_extension(Path("source.webm"), Path("output.mp4")) == ".mp4"
+        assert YouTubeDownloader._temp_processing_extension(Path("source.mkv"), Path("output.webm")) == ".webm"
+        assert YouTubeDownloader._temp_processing_extension(Path("source.mp4"), Path("output.mkv")) == ".mkv"
+
+    def test_input_has_alpha_checks_every_video_stream(self, temp_dir):
+        """A non-primary alpha stream must not be silently converted as opaque."""
+        downloader = YouTubeDownloader()
+        input_file = temp_dir / "input.mkv"
+        input_file.write_bytes(b"video data")
+        with patch.object(downloader, "_resolve_ffprobe_path", return_value="ffprobe"):
+            with patch("downloader.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="yuv420p\nyuva420p\n")
+                assert downloader._input_has_alpha(input_file)
+                assert "v" in mock_run.call_args.args[0]
 
     def test_cut_video_invalid_input(self, temp_dir):
         """Test cutting with non-existent input file"""
@@ -1743,25 +1811,32 @@ class TestDownloadVideo:
                     ):
                         with patch.object(downloader, "_check_file_stability", return_value=True):
                             with patch.object(downloader, "cut_video", return_value=True) as mock_cut:
+                                with patch.object(downloader, "_normalize_output_file") as mock_normalize:
 
-                                def cut_side_effect(
-                                    input_path,
-                                    output_path,
-                                    start_time=None,
-                                    end_time=None,
-                                ):
-                                    Path(output_path).write_bytes(b"cut data")
-                                    return True
+                                    def cut_side_effect(
+                                        input_path,
+                                        output_path,
+                                        start_time=None,
+                                        end_time=None,
+                                    ):
+                                        Path(output_path).write_bytes(b"cut data")
+                                        return True
 
-                                mock_cut.side_effect = cut_side_effect
-                                result = downloader.download_video(
-                                    "https://youtube.com/watch?v=test",
-                                    str(output_file),
-                                    start_time=10,
-                                    end_time=30,
-                                )
-                                assert result.success is True
-                                assert result.file_path == str(output_file)
+                                    def normalize_side_effect(_source, destination, _selected_format):
+                                        Path(destination).write_bytes(b"final data")
+                                        return True, None
+
+                                    mock_cut.side_effect = cut_side_effect
+                                    mock_normalize.side_effect = normalize_side_effect
+                                    result = downloader.download_video(
+                                        "https://youtube.com/watch?v=test",
+                                        str(output_file),
+                                        start_time=10,
+                                        end_time=30,
+                                    )
+                                    assert result.success is True
+                                    assert result.file_path == str(output_file)
+                                    assert mock_normalize.call_args.args[2] is None
 
     def test_download_multiple_sections(self, temp_dir, mock_ytdlp_download, sample_video_info):
         """Test downloading and cutting multiple sections"""
@@ -4042,27 +4117,29 @@ class TestMainFunction:
 
         with patch(
             "sys.argv",
-            ["downloader.py", "--local", str(input_file), "[]", str(output_file)],
+            ["downloader.py", "--local", str(input_file), '[{"start": null, "end": null}]', str(output_file)],
         ):
             with patch.object(
                 YouTubeDownloader,
                 "_normalize_output_file",
                 return_value=(True, None),
             ) as mock_normalize:
-                from downloader import main
+                with patch.object(YouTubeDownloader, "cut_and_concatenate_sections") as mock_cut:
+                    from downloader import main
 
-                with pytest.raises(SystemExit) as exc_info:
-                    main()
-                assert exc_info.value.code == 0
-                mock_normalize.assert_called_once()
-                called_src, called_dst = mock_normalize.call_args.args
-                assert called_src == input_file
-                assert called_dst == output_file
-                assert mock_normalize.call_args.kwargs.get("selected_format") is None
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 0
+                    mock_cut.assert_not_called()
+                    mock_normalize.assert_called_once()
+                    called_src, called_dst = mock_normalize.call_args.args
+                    assert called_src == input_file
+                    assert called_dst == output_file
+                    assert mock_normalize.call_args.kwargs.get("selected_format") is None
 
-                captured = capsys.readouterr()
-                output = json.loads(captured.out)
-                assert output["success"] is True
+                    captured = capsys.readouterr()
+                    output = json.loads(captured.out)
+                    assert output["success"] is True
 
     def test_main_download_mode_invalid_sections_json(self, temp_dir, capsys):
         """Test download mode with malformed sections JSON"""

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -1425,9 +1425,38 @@ class TestCutVideo:
         input_file.write_bytes(b"video data")
         with patch.object(downloader, "_resolve_ffprobe_path", return_value="ffprobe"):
             with patch("downloader.subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(stdout="yuv420p\nyuva420p\n")
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout='{"streams": [{"pix_fmt": "yuv420p"}, {"pix_fmt": "yuva420p"}]}',
+                )
                 assert downloader._input_has_alpha(input_file)
                 assert "v" in mock_run.call_args.args[0]
+
+    def test_input_has_alpha_detects_webm_alpha_metadata(self, temp_dir):
+        """WebM transparency can be stored in alpha_mode rather than pix_fmt."""
+        downloader = YouTubeDownloader()
+        input_file = temp_dir / "input.webm"
+        input_file.write_bytes(b"video data")
+        with patch.object(downloader, "_resolve_ffprobe_path", return_value="ffprobe"):
+            with patch("downloader.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout='{"streams": [{"pix_fmt": "yuv420p", "tags": {"alpha_mode": "1"}}]}',
+                )
+                assert downloader._input_has_alpha(input_file)
+
+    def test_text_subtitle_map_args_excludes_bitmap_subtitles(self, temp_dir):
+        """Text-only containers must not receive PGS/VobSub subtitle mappings."""
+        downloader = YouTubeDownloader()
+        input_file = temp_dir / "input.mkv"
+        input_file.write_bytes(b"video data")
+        with patch.object(downloader, "_resolve_ffprobe_path", return_value="ffprobe"):
+            with patch("downloader.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout='{"streams": [{"codec_name": "hdmv_pgs_subtitle"}, {"codec_name": "subrip"}]}',
+                )
+                assert downloader._text_subtitle_map_args(input_file, ".mp4") == ["-map", "0:s:1?"]
 
     def test_cut_video_invalid_input(self, temp_dir):
         """Test cutting with non-existent input file"""
@@ -3160,6 +3189,29 @@ class TestDownloadVideo:
                 None,
                 source_video_codec="h264",
                 source_audio_codec="mp4a.40.2",
+            )
+            is False
+        )
+
+    def test_requires_mp4_compatibility_transcode_rejects_prores_for_mp4(self):
+        """ProRes is valid in MOV but must not be remuxed into MP4."""
+        assert (
+            YouTubeDownloader._requires_mp4_compatibility_transcode(
+                Path("source.mov"),
+                Path("output.mp4"),
+                None,
+                source_video_codec="prores",
+                source_audio_codec="aac",
+            )
+            is True
+        )
+        assert (
+            YouTubeDownloader._requires_mp4_compatibility_transcode(
+                Path("source.mov"),
+                Path("output.mov"),
+                None,
+                source_video_codec="prores",
+                source_audio_codec="aac",
             )
             is False
         )

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -6,6 +6,7 @@ Covers all methods, edge cases, and error scenarios
 
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import time
@@ -1179,6 +1180,78 @@ class TestCutVideo:
         assert "-ss" in cmd
         assert "-t" in cmd
         assert "20" in cmd  # duration = end - start
+
+    def test_cut_video_decodes_before_seeking_to_honor_start_time(self, temp_dir, mock_subprocess_run):
+        """A non-keyframe start must be accurate, so stream copying is unsafe."""
+        input_file = temp_dir / "input.mp4"
+        input_file.write_bytes(b"video data")
+        output_file = temp_dir / "output.mp4"
+
+        downloader = YouTubeDownloader()
+        assert downloader.cut_video(str(input_file), str(output_file), start_time=5, end_time=8)
+
+        cmd = mock_subprocess_run.call_args.args[0]
+        assert cmd.index("-i") < cmd.index("-ss")
+        assert cmd[cmd.index("-i") + 1] == str(input_file)
+        assert "copy" not in cmd
+        assert cmd[cmd.index("-c:v") + 1] == "libx264"
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+    def test_cut_video_honors_non_keyframe_start_time(self, temp_dir, monkeypatch):
+        """Regression test for cuts that previously began at the prior keyframe."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        assert ffmpeg_path is not None
+        input_file = temp_dir / "input.mp4"
+        output_file = temp_dir / "output.mp4"
+
+        subprocess.run(
+            [
+                ffmpeg_path,
+                "-f",
+                "lavfi",
+                "-i",
+                "color=red:size=64x64:rate=5:duration=5",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=green:size=64x64:rate=5:duration=5",
+                "-filter_complex",
+                "[0:v][1:v]concat=n=2:v=1:a=0",
+                "-c:v",
+                "libx264",
+                "-g",
+                "50",
+                "-keyint_min",
+                "50",
+                "-sc_threshold",
+                "0",
+                str(input_file),
+                "-y",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        monkeypatch.setenv("FFMPEG_PATH", ffmpeg_path)
+
+        assert YouTubeDownloader().cut_video(str(input_file), str(output_file), start_time=5, end_time=8)
+
+        first_pixel = subprocess.run(
+            [
+                ffmpeg_path,
+                "-i",
+                str(output_file),
+                "-frames:v",
+                "1",
+                "-f",
+                "rawvideo",
+                "-pix_fmt",
+                "rgb24",
+                "-",
+            ],
+            capture_output=True,
+            check=True,
+        ).stdout[:3]
+        assert first_pixel[1] > first_pixel[0], "cut should start on the green five-second frame"
 
     def test_cut_video_invalid_input(self, temp_dir):
         """Test cutting with non-existent input file"""

--- a/python/test_downloader.py
+++ b/python/test_downloader.py
@@ -1191,10 +1191,12 @@ class TestCutVideo:
         assert downloader.cut_video(str(input_file), str(output_file), start_time=5, end_time=8)
 
         cmd = mock_subprocess_run.call_args.args[0]
-        assert cmd.index("-i") < cmd.index("-ss")
+        assert cmd.index("-ss") < cmd.index("-i")
         assert cmd[cmd.index("-i") + 1] == str(input_file)
         assert "copy" not in cmd
         assert cmd[cmd.index("-c:v") + 1] == "libx264"
+        assert cmd[cmd.index("-map") + 1] == "0:v:0?"
+        assert "pad=ceil(iw/2)*2:ceil(ih/2)*2" in cmd
 
     @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
     def test_cut_video_honors_non_keyframe_start_time(self, temp_dir, monkeypatch):
@@ -1252,6 +1254,112 @@ class TestCutVideo:
             check=True,
         ).stdout[:3]
         assert first_pixel[1] > first_pixel[0], "cut should start on the green five-second frame"
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+    def test_cut_video_preserves_mkv_subtitles_and_supports_audio_only_input(self, temp_dir, monkeypatch):
+        """Cuts retain compatible subtitles and do not require a video stream."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        ffprobe_path = shutil.which("ffprobe")
+        assert ffmpeg_path is not None
+        if ffprobe_path is None:
+            pytest.skip("ffprobe is required to verify subtitle preservation")
+        subtitle_file = temp_dir / "subtitle.srt"
+        subtitle_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nCaption\n", encoding="utf-8")
+        video_input = temp_dir / "input.mkv"
+        video_output = temp_dir / "output.mkv"
+        audio_input = temp_dir / "input.m4a"
+        audio_output = temp_dir / "output.m4a"
+
+        subprocess.run(
+            [
+                ffmpeg_path,
+                "-f",
+                "lavfi",
+                "-i",
+                "color=blue:size=64x64:rate=5:duration=3",
+                "-i",
+                str(subtitle_file),
+                "-map",
+                "0:v",
+                "-map",
+                "1:s",
+                "-c:v",
+                "libx264",
+                "-c:s",
+                "srt",
+                str(video_input),
+                "-y",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                ffmpeg_path,
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=3",
+                "-c:a",
+                "aac",
+                str(audio_input),
+                "-y",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        monkeypatch.setenv("FFMPEG_PATH", ffmpeg_path)
+        downloader = YouTubeDownloader()
+
+        assert downloader.cut_video(str(video_input), str(video_output), start_time=1, end_time=2)
+        assert downloader.cut_video(str(audio_input), str(audio_output), start_time=1, end_time=2)
+
+        subtitle_codecs = subprocess.run(
+            [
+                ffprobe_path,
+                "-v",
+                "error",
+                "-select_streams",
+                "s",
+                "-show_entries",
+                "stream=codec_name",
+                "-of",
+                "default=nw=1:nk=1",
+                str(video_output),
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+        assert "subrip" in subtitle_codecs
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+    def test_cut_video_pads_odd_video_dimensions(self, temp_dir, monkeypatch):
+        """H.264 cuts should work for valid sources with odd dimensions."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        assert ffmpeg_path is not None
+        input_file = temp_dir / "input.mkv"
+        output_file = temp_dir / "output.mp4"
+        subprocess.run(
+            [
+                ffmpeg_path,
+                "-f",
+                "lavfi",
+                "-i",
+                "color=yellow:size=65x65:rate=5:duration=3",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv444p",
+                str(input_file),
+                "-y",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        monkeypatch.setenv("FFMPEG_PATH", ffmpeg_path)
+
+        assert YouTubeDownloader().cut_video(str(input_file), str(output_file), start_time=1, end_time=2)
 
     def test_cut_video_invalid_input(self, temp_dir):
         """Test cutting with non-existent input file"""
@@ -1563,6 +1671,45 @@ class TestDownloadVideo:
                                 result = downloader.download_video("https://youtube.com/watch?v=test", str(output_file))
                                 assert result.success is True
                                 assert result.file_path == str(output_file)
+
+    def test_download_ignores_blank_section(self, temp_dir, mock_ytdlp_download, sample_video_info):
+        """The default empty UI section must not trigger a full-video cut."""
+        output_file = temp_dir / "output.mp4"
+        downloaded_file = temp_dir / f"{sample_video_info['id']}.mp4"
+        downloaded_file.write_bytes(b"video data")
+        downloader = YouTubeDownloader()
+
+        with patch.object(
+            downloader,
+            "extract_video_info",
+            return_value=VideoInfo(
+                id=sample_video_info["id"],
+                title=sample_video_info["title"],
+                duration=sample_video_info["duration"],
+                is_live=False,
+                is_scheduled=False,
+                scheduled_start_time=None,
+                thumbnail=None,
+                uploader=None,
+                view_count=None,
+                upload_date=None,
+            ),
+        ):
+            with patch.object(downloader, "_get_temp_dir", return_value=temp_dir):
+                with patch.object(downloader, "_get_cached_video_path", return_value=None):
+                    with patch.object(downloader, "_find_downloaded_file", return_value=downloaded_file):
+                        with patch.object(downloader, "_check_file_stability", return_value=True):
+                            with patch.object(downloader, "cut_and_concatenate_sections") as mock_cut:
+                                with patch("downloader.shutil.copy2") as mock_copy:
+                                    mock_copy.side_effect = lambda _src, dst: Path(dst).write_bytes(b"copied data")
+                                    result = downloader.download_video(
+                                        "https://youtube.com/watch?v=test",
+                                        str(output_file),
+                                        sections=[(None, None)],
+                                    )
+
+        assert result.success is True
+        mock_cut.assert_not_called()
 
     def test_download_single_section(self, temp_dir, mock_ytdlp_download, sample_video_info):
         """Test downloading and cutting single section"""

--- a/scripts/bundle-dependencies-linux.sh
+++ b/scripts/bundle-dependencies-linux.sh
@@ -124,20 +124,24 @@ FFMPEG_URL="https://github.com/yt-dlp/FFmpeg-Builds/releases/download/${FFMPEG_R
 
 curl -fSL -o ffmpeg.tar.xz "$FFMPEG_URL"
 echo "$FFMPEG_SHA256  ffmpeg.tar.xz" | sha256sum -c -
-tar -xf ffmpeg.tar.xz -C "$FFMPEG_DIR" --strip-components=2 "${FFMPEG_ARCHIVE_BASE}/bin/ffmpeg"
-chmod +x "$FFMPEG_DIR/ffmpeg"
+tar -xf ffmpeg.tar.xz -C "$FFMPEG_DIR" --strip-components=2 \
+  "${FFMPEG_ARCHIVE_BASE}/bin/ffmpeg" \
+  "${FFMPEG_ARCHIVE_BASE}/bin/ffprobe"
+chmod +x "$FFMPEG_DIR/ffmpeg" "$FFMPEG_DIR/ffprobe"
 rm -f ffmpeg.tar.xz
 
 "$FFMPEG_DIR/ffmpeg" -version >/dev/null 2>&1 || { echo "ERROR: bundled ffmpeg binary does not execute"; exit 1; }
+"$FFMPEG_DIR/ffprobe" -version >/dev/null 2>&1 || { echo "ERROR: bundled ffprobe binary does not execute"; exit 1; }
 echo "OK: FFmpeg bundled at $FFMPEG_DIR"
 
 printf '\n=== Summary ===\n'
-if [[ -f "$PYTHON_DIR/bin/python3" && -f "$PYTHON_DIR/downloader.py" && -f "$FFMPEG_DIR/ffmpeg" && -f "$JSRUNTIME_DIR/node" ]]; then
+if [[ -f "$PYTHON_DIR/bin/python3" && -f "$PYTHON_DIR/downloader.py" && -f "$FFMPEG_DIR/ffmpeg" && -f "$FFMPEG_DIR/ffprobe" && -f "$JSRUNTIME_DIR/node" ]]; then
   echo "All dependencies bundled for Tauri."
   echo "Python: $PYTHON_DIR/bin/python3"
   echo "Script: $PYTHON_DIR/downloader.py"
   echo "JS runtime: $JSRUNTIME_DIR/node"
   echo "FFmpeg: $FFMPEG_DIR/ffmpeg"
+  echo "FFprobe: $FFMPEG_DIR/ffprobe"
   echo "Next: pnpm tauri:build:linux"
 else
   echo "Dependency bundling failed."

--- a/scripts/bundle-dependencies-macos.sh
+++ b/scripts/bundle-dependencies-macos.sh
@@ -108,10 +108,14 @@ case "$PYTHON_ARCH" in
   arm64 | aarch64)
     FFMPEG_URL="https://ffmpeg.martin-riedl.de/download/macos/arm64/1785863997_9.0/ffmpeg.zip"
     FFMPEG_SHA256="5267ef149ee0d208057a1b316aac079b661b0476574dee5da7d225769773c603"
+    FFPROBE_URL="https://ffmpeg.martin-riedl.de/download/macos/arm64/1785863997_9.0/ffprobe.zip"
+    FFPROBE_SHA256="7778fbb533fb60d3336cbd9a9e51eced71658f020b570c7203590c1c41d42f50"
     ;;
   x86_64)
     FFMPEG_URL="https://ffmpeg.martin-riedl.de/download/macos/amd64/1785871427_9.0/ffmpeg.zip"
     FFMPEG_SHA256="79d14663d8b078dbbc38de18d63a30f8a5bfc860af5dfee7f8cf3e387cf1c02c"
+    FFPROBE_URL="https://ffmpeg.martin-riedl.de/download/macos/amd64/1785871427_9.0/ffprobe.zip"
+    FFPROBE_SHA256="a2dd3f2e7eb35a10fa6ac43b1a8c21890f27bee0dc4a86ddee16a57d72d3898d"
     ;;
   *)
     echo "Unsupported macOS architecture for bundled FFmpeg: $PYTHON_ARCH"
@@ -125,7 +129,14 @@ unzip -o ffmpeg.zip -d "$FFMPEG_DIR"
 chmod +x "$FFMPEG_DIR/ffmpeg"
 rm -f ffmpeg.zip
 
+curl -fSL -o ffprobe.zip "$FFPROBE_URL"
+echo "$FFPROBE_SHA256  ffprobe.zip" | shasum -a 256 -c -
+unzip -o ffprobe.zip -d "$FFMPEG_DIR"
+chmod +x "$FFMPEG_DIR/ffprobe"
+rm -f ffprobe.zip
+
 "$FFMPEG_DIR/ffmpeg" -version >/dev/null 2>&1 || { echo "ERROR: bundled ffmpeg binary does not execute"; exit 1; }
+"$FFMPEG_DIR/ffprobe" -version >/dev/null 2>&1 || { echo "ERROR: bundled ffprobe binary does not execute"; exit 1; }
 echo "OK: FFmpeg bundled at $FFMPEG_DIR"
 
 printf '\n=== Step 4: macOS code signing for bundled runtimes ===\n'
@@ -152,12 +163,13 @@ else
 fi
 
 printf '\n=== Summary ===\n'
-if [[ -f "$PYTHON_DIR/bin/python3" && -f "$PYTHON_DIR/downloader.py" && -f "$FFMPEG_DIR/ffmpeg" && -f "$JSRUNTIME_DIR/deno" ]]; then
+if [[ -f "$PYTHON_DIR/bin/python3" && -f "$PYTHON_DIR/downloader.py" && -f "$FFMPEG_DIR/ffmpeg" && -f "$FFMPEG_DIR/ffprobe" && -f "$JSRUNTIME_DIR/deno" ]]; then
   echo "All dependencies bundled for Tauri."
   echo "Python: $PYTHON_DIR/bin/python3"
   echo "Script: $PYTHON_DIR/downloader.py"
   echo "JS runtime: $JSRUNTIME_DIR/deno"
   echo "FFmpeg: $FFMPEG_DIR/ffmpeg"
+  echo "FFprobe: $FFMPEG_DIR/ffprobe"
   echo "Next: pnpm tauri:build:mac"
 else
   echo "Dependency bundling failed."

--- a/scripts/bundle-dependencies-windows.ps1
+++ b/scripts/bundle-dependencies-windows.ps1
@@ -124,10 +124,12 @@ try {
     Expand-Archive -Path ffmpeg.zip -DestinationPath ffmpeg-temp -Force
 
     $ffmpegSource = Get-ChildItem ffmpeg-temp -Recurse -Filter ffmpeg.exe | Select-Object -First 1
-    if ($null -eq $ffmpegSource) {
-        throw "Failed to locate ffmpeg.exe in archive"
+    $ffprobeSource = Get-ChildItem ffmpeg-temp -Recurse -Filter ffprobe.exe | Select-Object -First 1
+    if ($null -eq $ffmpegSource -or $null -eq $ffprobeSource) {
+        throw "Failed to locate ffmpeg.exe or ffprobe.exe in archive"
     }
     Copy-Item $ffmpegSource.FullName (Join-Path $ffmpegDir "ffmpeg.exe") -Force
+    Copy-Item $ffprobeSource.FullName (Join-Path $ffmpegDir "ffprobe.exe") -Force
     Remove-Item -Recurse -Force ffmpeg-temp
     Remove-Item ffmpeg.zip
 } catch {
@@ -142,14 +144,16 @@ Write-Host "`n=== Summary ===" -ForegroundColor Yellow
 $pythonExe = Join-Path $pythonDir "python.exe"
 $pythonScript = Join-Path $pythonDir "downloader.py"
 $ffmpegExe = Join-Path $ffmpegDir "ffmpeg.exe"
+$ffprobeExe = Join-Path $ffmpegDir "ffprobe.exe"
 $nodeExe = Join-Path $jsRuntimeDir "node.exe"
 
-if ((Test-Path $pythonExe) -and (Test-Path $pythonScript) -and (Test-Path $ffmpegExe) -and (Test-Path $nodeExe)) {
+if ((Test-Path $pythonExe) -and (Test-Path $pythonScript) -and (Test-Path $ffmpegExe) -and (Test-Path $ffprobeExe) -and (Test-Path $nodeExe)) {
     Write-Host "All dependencies bundled for Tauri." -ForegroundColor Green
     Write-Host "Python: $pythonExe"
     Write-Host "Script: $pythonScript"
     Write-Host "JS runtime: $nodeExe"
     Write-Host "FFmpeg: $ffmpegExe"
+    Write-Host "FFprobe: $ffprobeExe"
     Write-Host "Next: pnpm tauri:build:win"
 } else {
     throw "Dependency bundling failed"

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -18,7 +18,7 @@ const resourcesDirs = [
 	{
 		path: join(resourcesRoot, "ffmpeg"),
 		name: "FFmpeg",
-		required: isWindows ? ["ffmpeg.exe"] : ["ffmpeg"],
+		required: isWindows ? ["ffmpeg.exe", "ffprobe.exe"] : ["ffmpeg", "ffprobe"],
 	},
 	{
 		path: join(resourcesRoot, "jsruntime"),


### PR DESCRIPTION
## Summary

Make video section cuts frame-accurate so requested start times no longer snap back to an earlier keyframe.

## Root cause

The cutter used FFmpeg stream copy with input seeking. FFmpeg can only start copied streams at a preceding keyframe, so a 0:05 cut could retain frames from 0:00.

## Changes

- Decode and seek to the requested timestamp before re-encoding cut output.
- Preserve MP4/MKV and WebM-compatible encoding paths.
- Add command-level and real FFmpeg sparse-keyframe regression coverage.

## Validation

- `.venv/bin/python -m pytest python/test_downloader.py -q` — 185 passed
- Pre-push checks: Biome, Clippy, Ruff, ShellCheck, TypeScript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video clips now start at the requested frame, including cuts that do not align with keyframes.
  * Exported videos retain their primary video and audio streams with format-appropriate encoding.
* **Tests**
  * Added coverage for frame-accurate cuts and validated output using FFmpeg-backed regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->