### PR TITLE
fix: scope footer website opener permission

### DIFF
--- a/app/components/AppFooter.tsx
+++ b/app/components/AppFooter.tsx
@@ -4,7 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useState } from "react";
 import packageJson from "../../package.json";
 
-const WEBSITE_URL = "https://arpit.im?utm_source=yt-downloader&utm_medium=app";
+const WEBSITE_URL = "https://arpit.im/?utm_source=yt-downloader&utm_medium=app";
 
 export function AppFooter() {
 	const [version, setVersion] = useState(packageJson.version);

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,7 +7,10 @@
 		"core:default",
 		"dialog:default",
 		"log:default",
-		"opener:default",
+		{
+			"identifier": "opener:allow-open-url",
+			"allow": [{ "url": "https://arpit.im/*" }]
+		},
 		"process:allow-restart",
 		"updater:default"
 	]


### PR DESCRIPTION
## Summary

Restrict the Tauri opener capability to the Arpit Dalal website used by the app footer.

## Root cause

The footer link needed `openUrl`, but `opener:default` also permits broad URL schemes and revealing filesystem items.

## Change

Replace the default opener permission with a scoped `openUrl` permission for `https://arpit.im/*`. The footer URL now uses a trailing slash so it matches that origin-bound glob.

## Impact

The footer link continues to launch the system browser, while unrelated opener operations and destinations remain unavailable.

## Validation

- `pnpm lint:ts`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Pre-push checks: Biome, Clippy, Ruff, ShellCheck, TypeScript, release-tag validation